### PR TITLE
Use MinGW-w64 for building C libraries in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
   - set PATH=%PATH%;C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin
   - cd C:\projects\dhmqc
+  # Showing PATH may help in debugging failing builds
   - echo %PATH%
   # MSVC not yet supported for C++ compilation
   - python src\build\build.py -x64 -v -cc C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\gcc.exe
@@ -40,6 +41,7 @@ test_script:
   # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
   - set PATH=
   - call %OSGEO4W_ROOT%\bin\o4w_env.bat
+  - set PATH=%PATH%;C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin
   - cd C:\projects\dhmqc
   - echo %PATH%
   - nosetests tests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,16 @@ build_script:
   - set PATH=
   - call %OSGEO4W_ROOT%\bin\o4w_env.bat
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+  - set PATH=%PATH%;C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin
   - cd C:\projects\dhmqc
-  - python src\build\build.py -x64 -msvc
+  - echo %PATH%
+  # MSVC not yet supported for C++ compilation
+  - python src\build\build.py -x64 -v -cc C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin\gcc.exe
 
 test_script:
   # FIXME: Clear PATH to avoid OSGeo4W loading incompatible DLLs
   - set PATH=
   - call %OSGEO4W_ROOT%\bin\o4w_env.bat
   - cd C:\projects\dhmqc
+  - echo %PATH%
   - nosetests tests.py


### PR DESCRIPTION
This PR causes the AppVeyor CI script to build with MinGW/GCC rather than MSVC. PR #22 requires `g++`, and the purpose of this PR is to isolate the CI-related changes in preparation for that.