### PR TITLE
Fix sporadic Travis CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - make
   - sudo make install
   - cd ..
-  - wget http://lastools.org/download/LAStools.zip
+  - wget http://www.cs.unc.edu/~isenburg/lastools/download/LAStools.zip
   - unzip LAStools.zip
   - cd LAStools
   - make


### PR DESCRIPTION
The Travis CI builds sometimes (but not always) fail due to garbled URLs in HTTP redirects when `wget`ing LAStools. This PR causes those redirects to be skipped.