### PR TITLE
Bulk futurize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n dhmqc_env -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose coverage coveralls
+  - conda create -q -n dhmqc_env -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose coverage coveralls
   - conda activate dhmqc_env
   - python src/build/build.py -v -x64 -force -cc gcc -cxx g++
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n dhmqc_env -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose coverage coveralls
+  - conda create -q -n dhmqc_env -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose coverage coveralls
   - conda activate dhmqc_env
   - python src/build/build.py -v -x64 -force -cc gcc -cxx g++
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose
+  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose
   # AppVeyor has its own activate.bat in lieu of "conda activate"
   - activate %CONDA_ENV_NAME%
   - echo %PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose
+  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose
   # AppVeyor has its own activate.bat in lieu of "conda activate"
   - activate %CONDA_ENV_NAME%
   - echo %PATH%

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,7 +9,7 @@ First off, ensure you have C and C++ compilers installed (on Unix, `gcc` and `g+
 ### Setting up a Conda environment ###
 The recommended way of installing DHMQC is using a Conda environment.
 1. Ensure you have [Anaconda](https://www.anaconda.com/distribution/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installed. Get the Python 3.x, 64-bit version for your platform.
-2. Open an Anaconda prompt, then create a new environment with `conda create --name DHMQC_ENV --channel conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose git` (replace `DHMQC_ENV` with your desired name for the environment. You can skip `git` if you have Git installed systemwide.)
+2. Open an Anaconda prompt, then create a new environment with `conda create --name DHMQC_ENV --channel conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose git` (replace `DHMQC_ENV` with your desired name for the environment. You can skip `git` if you have Git installed systemwide.)
 3. Switch to your new environment with `conda activate DHMQC_ENV` (replace `DHMQC_ENV` with the name entered above). You will need to run this "activate" command every time you launch an Anaconda prompt.
 
 ### Clone the DHMQC repository ###

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -9,7 +9,7 @@ First off, ensure you have C and C++ compilers installed (on Unix, `gcc` and `g+
 ### Setting up a Conda environment ###
 The recommended way of installing DHMQC is using a Conda environment.
 1. Ensure you have [Anaconda](https://www.anaconda.com/distribution/) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) installed. Get the Python 3.x, 64-bit version for your platform.
-2. Open an Anaconda prompt, then create a new environment with `conda create --name DHMQC_ENV --channel conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools future nose git` (replace `DHMQC_ENV` with your desired name for the environment. You can skip `git` if you have Git installed systemwide.)
+2. Open an Anaconda prompt, then create a new environment with `conda create --name DHMQC_ENV --channel conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose git` (replace `DHMQC_ENV` with your desired name for the environment. You can skip `git` if you have Git installed systemwide.)
 3. Switch to your new environment with `conda activate DHMQC_ENV` (replace `DHMQC_ENV` with the name entered above). You will need to run this "activate" command every time you launch an Anaconda prompt.
 
 ### Clone the DHMQC repository ###

--- a/pcm.py
+++ b/pcm.py
@@ -14,6 +14,9 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import input
+from builtins import str
+from builtins import range
 import sys,os,time
 import traceback
 import multiprocessing
@@ -188,7 +191,7 @@ if __name__=="__main__":
         print("Successfully created processing tables in "+cstr)
 
     def drop_tables(cstr):
-        areyousure=raw_input("Are you really, really sure you wanna drop tables and kill all clients? [YES/no]:")
+        areyousure=input("Are you really, really sure you wanna drop tables and kill all clients? [YES/no]:")
         if areyousure.strip()=="YES":
             print("OK - you told me to do it!")
             con=db.connect(cstr)

--- a/pcm.py
+++ b/pcm.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -52,7 +53,7 @@ def proc_client(p_number,db_cstr,lock):
     try:
         con=db.connect(db_cstr)
         cur=con.cursor()
-    except Exception,e:
+    except Exception as e:
         logger.error("Unable to connect db:\n"+str(e))
         return #stop
     time.sleep(2+random.random()*2)
@@ -106,7 +107,7 @@ def proc_client(p_number,db_cstr,lock):
             send_args+=targs
             rc=test_func(send_args)
 
-        except Exception,e:
+        except Exception as e:
             stderr.write("[proc_client]: Exception caught:\n"+str(e)+"\n")
             stderr.write("[proc_client]: Traceback:\n"+traceback.format_exc()+"\n")
             logger.error("Caught: \n"+str(e))
@@ -217,7 +218,7 @@ if __name__=="__main__":
             try: #or use ogr-geometry
                 tile=constants.get_tilename(tile_path)
                 wkt=constants.tilename_to_extent(tile,return_wkt=True)
-            except Exception,e:
+            except Exception as e:
                 print("Bad tilename in "+tile_path)
                 continue
             cur.execute("insert into proc_jobs(wkb_geometry,tile_name,path,ref_cstr,job_id,status,priority,version) values(st_geomfromtext(%s,25832),%s,%s,%s,%s,%s,%s,%s)",(wkt,tile,tile_path,ref_path,job_id,0,priority,0))

--- a/pcm.py
+++ b/pcm.py
@@ -14,9 +14,6 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import input
-from builtins import str
-from builtins import range
 import sys,os,time
 import traceback
 import multiprocessing
@@ -191,7 +188,7 @@ if __name__=="__main__":
         print("Successfully created processing tables in "+cstr)
 
     def drop_tables(cstr):
-        areyousure=input("Are you really, really sure you wanna drop tables and kill all clients? [YES/no]:")
+        areyousure=raw_input("Are you really, really sure you wanna drop tables and kill all clients? [YES/no]:")
         if areyousure.strip()=="YES":
             print("OK - you told me to do it!")
             con=db.connect(cstr)

--- a/proc_setup.py
+++ b/proc_setup.py
@@ -48,6 +48,8 @@ NAMES WHICH CAN BE DEFINED IN PARAM-FILE:
 '''
 from __future__ import print_function
 
+from builtins import str
+from builtins import object
 import os
 import shlex
 import textwrap
@@ -63,7 +65,7 @@ from qc import dhmqc_constants as constants
 # dropped, a search-and-replace of "unicode" -> "str" may be done on this
 # module.
 if sys.version_info[0] >= 3:
-    unicode = str
+    str = str
 
 def execute_file(filename, globals=None, locals=None):
     """"Execute a .py file. Essentially, provide execfile() for Python 3."""
@@ -88,12 +90,12 @@ class StatusUpdater(object):
 
 # names that can be defined in parameter file (or on command line):
 QC_WRAP_NAMES = {"TESTNAME": str,
-                 "INPUT_TILE_CONNECTION": unicode,
+                 "INPUT_TILE_CONNECTION": str,
                  "INPUT_LAYER_SQL": str,  # ExecuteSQL does not like unicode...
                  "USE_LOCAL": bool,
                  "SCHEMA": str,
-                 "REF_DATA_CONNECTION": unicode,
-                 "REF_TILE_DB": unicode,
+                 "REF_DATA_CONNECTION": str,
+                 "REF_TILE_DB": str,
                  "REF_TILE_TABLE": str,
                  "REF_TILE_NAME_FIELD": str,
                  "REF_TILE_PATH_FIELD": str,
@@ -106,11 +108,11 @@ QC_WRAP_NAMES = {"TESTNAME": str,
 
 # Names which are relevant for job definitions for the 'listening client'
 PCM_NAMES = {"TESTNAME": str,
-             "INPUT_TILE_CONNECTION": unicode,
+             "INPUT_TILE_CONNECTION": str,
              "INPUT_LAYER_SQL": str,  # ExecuteSQL does not like unicode...
              "SCHEMA": str,
-             "REF_DATA_CONNECTION": unicode,
-             "REF_TILE_DB": unicode,
+             "REF_DATA_CONNECTION": str,
+             "REF_TILE_DB": str,
              "REF_TILE_TABLE": str,
              "REF_TILE_NAME_FIELD": str,
              "REF_TILE_PATH_FIELD": str,
@@ -150,11 +152,11 @@ def get_definitions(all_names, defaults, definitions, override=None):
     Override is another similar dict (perhaps from commandline args, which
     Should take precedence and override the first definitions.
     '''
-    args = dict.fromkeys(all_names.keys(), None)  # all is None
+    args = dict.fromkeys(list(all_names.keys()), None)  # all is None
     args.update(defaults)  # add some defaults if relevant
     # normalise arguments...  iterate over all relevant keys (could be more in
     # definitions or override)
-    for key in all_names.keys():
+    for key in list(all_names.keys()):
         val = None
         if key in definitions and definitions[key] is not None:
             val = definitions[key]
@@ -166,7 +168,7 @@ def get_definitions(all_names, defaults, definitions, override=None):
         if val is not None:
             # apply converters
             if key == "TARGS":
-                if isinstance(val, str) or isinstance(val, unicode):
+                if isinstance(val, str) or isinstance(val, str):
                     val = shlex.split(val)
             try:
                 val = all_names[key](val)

--- a/proc_setup.py
+++ b/proc_setup.py
@@ -61,6 +61,12 @@ import qc
 from qc.db import report
 from qc import dhmqc_constants as constants
 
+# Ensures compatibility with both Python 2.7 and 3.x. Once 2.x support can be
+# dropped, a search-and-replace of "unicode" -> "str" may be done on this
+# module.
+if sys.version_info[0] >= 3:
+    str = str
+
 def execute_file(filename, globals=None, locals=None):
     """"Execute a .py file. Essentially, provide execfile() for Python 3."""
     with open(filename, 'r') as file:

--- a/proc_setup.py
+++ b/proc_setup.py
@@ -61,12 +61,6 @@ import qc
 from qc.db import report
 from qc import dhmqc_constants as constants
 
-# Ensures compatibility with both Python 2.7 and 3.x. Once 2.x support can be
-# dropped, a search-and-replace of "unicode" -> "str" may be done on this
-# module.
-if sys.version_info[0] >= 3:
-    str = str
-
 def execute_file(filename, globals=None, locals=None):
     """"Execute a .py file. Essentially, provide execfile() for Python 3."""
     with open(filename, 'r') as file:

--- a/proc_setup.py
+++ b/proc_setup.py
@@ -48,8 +48,6 @@ NAMES WHICH CAN BE DEFINED IN PARAM-FILE:
 '''
 from __future__ import print_function
 
-from builtins import str
-from builtins import object
 import os
 import shlex
 import textwrap
@@ -65,7 +63,7 @@ from qc import dhmqc_constants as constants
 # dropped, a search-and-replace of "unicode" -> "str" may be done on this
 # module.
 if sys.version_info[0] >= 3:
-    str = str
+    unicode = str
 
 def execute_file(filename, globals=None, locals=None):
     """"Execute a .py file. Essentially, provide execfile() for Python 3."""
@@ -90,12 +88,12 @@ class StatusUpdater(object):
 
 # names that can be defined in parameter file (or on command line):
 QC_WRAP_NAMES = {"TESTNAME": str,
-                 "INPUT_TILE_CONNECTION": str,
+                 "INPUT_TILE_CONNECTION": unicode,
                  "INPUT_LAYER_SQL": str,  # ExecuteSQL does not like unicode...
                  "USE_LOCAL": bool,
                  "SCHEMA": str,
-                 "REF_DATA_CONNECTION": str,
-                 "REF_TILE_DB": str,
+                 "REF_DATA_CONNECTION": unicode,
+                 "REF_TILE_DB": unicode,
                  "REF_TILE_TABLE": str,
                  "REF_TILE_NAME_FIELD": str,
                  "REF_TILE_PATH_FIELD": str,
@@ -108,11 +106,11 @@ QC_WRAP_NAMES = {"TESTNAME": str,
 
 # Names which are relevant for job definitions for the 'listening client'
 PCM_NAMES = {"TESTNAME": str,
-             "INPUT_TILE_CONNECTION": str,
+             "INPUT_TILE_CONNECTION": unicode,
              "INPUT_LAYER_SQL": str,  # ExecuteSQL does not like unicode...
              "SCHEMA": str,
-             "REF_DATA_CONNECTION": str,
-             "REF_TILE_DB": str,
+             "REF_DATA_CONNECTION": unicode,
+             "REF_TILE_DB": unicode,
              "REF_TILE_TABLE": str,
              "REF_TILE_NAME_FIELD": str,
              "REF_TILE_PATH_FIELD": str,
@@ -152,11 +150,11 @@ def get_definitions(all_names, defaults, definitions, override=None):
     Override is another similar dict (perhaps from commandline args, which
     Should take precedence and override the first definitions.
     '''
-    args = dict.fromkeys(list(all_names.keys()), None)  # all is None
+    args = dict.fromkeys(all_names.keys(), None)  # all is None
     args.update(defaults)  # add some defaults if relevant
     # normalise arguments...  iterate over all relevant keys (could be more in
     # definitions or override)
-    for key in list(all_names.keys()):
+    for key in all_names.keys():
         val = None
         if key in definitions and definitions[key] is not None:
             val = definitions[key]
@@ -168,7 +166,7 @@ def get_definitions(all_names, defaults, definitions, override=None):
         if val is not None:
             # apply converters
             if key == "TARGS":
-                if isinstance(val, str) or isinstance(val, str):
+                if isinstance(val, str) or isinstance(val, unicode):
                     val = shlex.split(val)
             try:
                 val = all_names[key](val)

--- a/qc/burn_baby_burn.py
+++ b/qc/burn_baby_burn.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -76,15 +78,15 @@ from osgeo    import ogr
 from osgeo    import osr
 
 #import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
-from db       import report
+from .thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
+from .db       import report
 
 
-import dhmqc_constants as constants
+from . import dhmqc_constants as constants
 
 # If you want this script to be included in the test-suite use this subclass.
 # Otherwise argparse.ArgumentParser will be the best choice :-)
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
 # To always get the proper name in usage / help - even when called from a wrapper...
 progname=os.path.basename(__file__).replace(".pyc",".py")

--- a/qc/burn_baby_burn.py
+++ b/qc/burn_baby_burn.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -64,6 +65,10 @@ from __future__ import absolute_import
 
 
 
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import sys
 import os
 import time
@@ -119,11 +124,11 @@ TARGET=np.array((0, 0, 1, 0, 1, 1, 0, 1),  dtype = np.float64)
 
 
 def transform(xy, cm, scale, H):
-    xy = (xy - cm)/scale
+    xy = old_div((xy - cm),scale)
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(H, xy.T)
     p  = xy[-1,:].copy()
-    xy = xy / p
+    xy = old_div(xy, p)
     xy = (xy.T)[:,:-1]
     return xy
 
@@ -132,7 +137,7 @@ def inverse_transform(xy, cm, scale, Hinv):
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(Hinv, xy.T)
     p  = xy[-1,:].copy()
-    xy = xy / p
+    xy = old_div(xy, p)
     xy = (xy.T)[:,:-1]
     xy = xy * scale + cm
     return xy
@@ -146,9 +151,9 @@ def get_transformation_params(arr,resolution):
     ndxy2 = np.sqrt(np.dot(dxy2,dxy2.T))
 
     #now move to cm-coords
-    nsteps = max(math.ceil(max(ndxy1,ndxy2)/resolution),2)
+    nsteps = max(math.ceil(old_div(max(ndxy1,ndxy2),resolution)),2)
     scale  = (ndxy1 + ndxy2)*0.5
-    tarr   = (arr - cm)/scale
+    tarr   = old_div((arr - cm),scale)
 
     #setup equations
     A=np.zeros((8,8),  dtype = np.float64)
@@ -226,7 +231,7 @@ def create_3d_lines(stuff_to_handle,layer,resolution,ndval):
         dxy2=arr[2]-arr[1] # 1 to 2
         ndxy1=np.sqrt(np.dot(dxy1,dxy1.T))
         ndxy2=np.sqrt(np.dot(dxy2,dxy2.T))
-        nsteps=int(max(math.ceil(max(ndxy1,ndxy2)/resolution),2))
+        nsteps=int(max(math.ceil(old_div(max(ndxy1,ndxy2),resolution)),2))
         h=np.linspace(0,1,nsteps,endpoint=True).reshape((nsteps,1))
         l1=h*dxy1+arr[0]
         l2=h*dxy2+arr[1]

--- a/qc/burn_baby_burn.py
+++ b/qc/burn_baby_burn.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -65,10 +64,6 @@ from __future__ import division
 
 
 
-from builtins import str
-from builtins import range
-from builtins import object
-from past.utils import old_div
 import sys
 import os
 import time
@@ -124,11 +119,11 @@ TARGET=np.array((0, 0, 1, 0, 1, 1, 0, 1),  dtype = np.float64)
 
 
 def transform(xy, cm, scale, H):
-    xy = old_div((xy - cm),scale)
+    xy = (xy - cm)/scale
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(H, xy.T)
     p  = xy[-1,:].copy()
-    xy = old_div(xy, p)
+    xy = xy / p
     xy = (xy.T)[:,:-1]
     return xy
 
@@ -137,7 +132,7 @@ def inverse_transform(xy, cm, scale, Hinv):
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(Hinv, xy.T)
     p  = xy[-1,:].copy()
-    xy = old_div(xy, p)
+    xy = xy / p
     xy = (xy.T)[:,:-1]
     xy = xy * scale + cm
     return xy
@@ -151,9 +146,9 @@ def get_transformation_params(arr,resolution):
     ndxy2 = np.sqrt(np.dot(dxy2,dxy2.T))
 
     #now move to cm-coords
-    nsteps = max(math.ceil(old_div(max(ndxy1,ndxy2),resolution)),2)
+    nsteps = max(math.ceil(max(ndxy1,ndxy2)/resolution),2)
     scale  = (ndxy1 + ndxy2)*0.5
-    tarr   = old_div((arr - cm),scale)
+    tarr   = (arr - cm)/scale
 
     #setup equations
     A=np.zeros((8,8),  dtype = np.float64)
@@ -231,7 +226,7 @@ def create_3d_lines(stuff_to_handle,layer,resolution,ndval):
         dxy2=arr[2]-arr[1] # 1 to 2
         ndxy1=np.sqrt(np.dot(dxy1,dxy1.T))
         ndxy2=np.sqrt(np.dot(dxy2,dxy2.T))
-        nsteps=int(max(math.ceil(old_div(max(ndxy1,ndxy2),resolution)),2))
+        nsteps=int(max(math.ceil(max(ndxy1,ndxy2)/resolution),2))
         h=np.linspace(0,1,nsteps,endpoint=True).reshape((nsteps,1))
         l1=h*dxy1+arr[0]
         l2=h*dxy2+arr[1]

--- a/qc/burn_baby_burn.py
+++ b/qc/burn_baby_burn.py
@@ -64,6 +64,9 @@ from __future__ import absolute_import
 
 
 
+from builtins import str
+from builtins import range
+from builtins import object
 import sys
 import os
 import time

--- a/qc/burn_horse_shoes.py
+++ b/qc/burn_horse_shoes.py
@@ -57,6 +57,7 @@ from __future__ import absolute_import
 
 
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/burn_horse_shoes.py
+++ b/qc/burn_horse_shoes.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -64,15 +66,15 @@ import numpy as np
 import shutil
 
 #import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
-from db       import report
+from .thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
+from .db       import report
 from osgeo    import gdal
 
-import dhmqc_constants as constants
+from . import dhmqc_constants as constants
 
 # If you want this script to be included in the test-suite use this subclass.
 # Otherwise argparse.ArgumentParser will be the best choice :-)
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
 # To always get the proper name in usage / help - even when called from a wrapper...
 progname=os.path.basename(__file__).replace(".pyc",".py")

--- a/qc/burn_horse_shoes.py
+++ b/qc/burn_horse_shoes.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -57,6 +58,8 @@ from __future__ import absolute_import
 
 
 
+from builtins import str
+from past.utils import old_div
 import sys
 import os
 import time
@@ -107,11 +110,11 @@ TARGET=np.array((0, 0, 1, 0, 1, 1, 0, 1),  dtype = np.float64)
 
 
 def transform(xy, cm, scale, H):
-    xy = (xy - cm)/scale
+    xy = old_div((xy - cm),scale)
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(H, xy.T)
     p  = xy[-1,:].copy()
-    xy = xy / p
+    xy = old_div(xy, p)
     xy = (xy.T)[:,:-1]
     return xy
 
@@ -120,7 +123,7 @@ def inverse_transform(xy, cm, scale, Hinv):
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(Hinv, xy.T)
     p  = xy[-1,:].copy()
-    xy = xy / p
+    xy = old_div(xy, p)
     xy = (xy.T)[:,:-1]
     xy = xy * scale + cm
     return xy
@@ -134,9 +137,9 @@ def get_transformation_params(arr):
     ndxy2 = np.sqrt(np.dot(dxy2,dxy2.T))
 
     #now move to cm-coords
-    nsteps = max(math.ceil(max(ndxy1,ndxy2)/RESOLUTION),2)
+    nsteps = max(math.ceil(old_div(max(ndxy1,ndxy2),RESOLUTION)),2)
     scale  = (ndxy1 + ndxy2)*0.5
-    tarr   = (arr - cm)/scale
+    tarr   = old_div((arr - cm),scale)
 
     #setup equations
     A=np.zeros((8,8),  dtype = np.float64)

--- a/qc/burn_horse_shoes.py
+++ b/qc/burn_horse_shoes.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -58,8 +57,6 @@ from __future__ import division
 
 
 
-from builtins import str
-from past.utils import old_div
 import sys
 import os
 import time
@@ -110,11 +107,11 @@ TARGET=np.array((0, 0, 1, 0, 1, 1, 0, 1),  dtype = np.float64)
 
 
 def transform(xy, cm, scale, H):
-    xy = old_div((xy - cm),scale)
+    xy = (xy - cm)/scale
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(H, xy.T)
     p  = xy[-1,:].copy()
-    xy = old_div(xy, p)
+    xy = xy / p
     xy = (xy.T)[:,:-1]
     return xy
 
@@ -123,7 +120,7 @@ def inverse_transform(xy, cm, scale, Hinv):
     xy = np.column_stack((xy, np.ones((xy.shape[0],)))) #append projective last coord
     xy = np.dot(Hinv, xy.T)
     p  = xy[-1,:].copy()
-    xy = old_div(xy, p)
+    xy = xy / p
     xy = (xy.T)[:,:-1]
     xy = xy * scale + cm
     return xy
@@ -137,9 +134,9 @@ def get_transformation_params(arr):
     ndxy2 = np.sqrt(np.dot(dxy2,dxy2.T))
 
     #now move to cm-coords
-    nsteps = max(math.ceil(old_div(max(ndxy1,ndxy2),RESOLUTION)),2)
+    nsteps = max(math.ceil(max(ndxy1,ndxy2)/RESOLUTION),2)
     scale  = (ndxy1 + ndxy2)*0.5
-    tarr   = old_div((arr - cm),scale)
+    tarr   = (arr - cm)/scale
 
     #setup equations
     A=np.zeros((8,8),  dtype = np.float64)

--- a/qc/burn_horse_shoes_lines.py
+++ b/qc/burn_horse_shoes_lines.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -17,13 +19,13 @@
 import sys,os,time
 import math
 #import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
-from db import report
+from .thatsDEM import pointcloud, vector_io, array_geometry, grid, triangle
+from .db import report
 import shutil
 import numpy as np
 from osgeo import gdal, ogr
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 
 #####################################################################################
 ##  Burn horse shoes by generating 3d lines. Would be better to generate and store the lines and then just use gdal_rasterize.
@@ -59,7 +61,7 @@ def usage():
 def main(args):
     try:
         pargs=parser.parse_args(args[1:])
-    except Exception,e:
+    except Exception as e:
         print(str(e))
         return 1
     kmname=constants.get_tilename(pargs.dem_tile)

--- a/qc/burn_horse_shoes_lines.py
+++ b/qc/burn_horse_shoes_lines.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,6 +17,9 @@ from __future__ import absolute_import
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 import math
 #import some relevant modules...
@@ -124,7 +128,7 @@ def main(args):
         dxy2=arr[2]-arr[1] # 1 to 2
         ndxy1=np.sqrt(np.dot(dxy1,dxy1.T))
         ndxy2=np.sqrt(np.dot(dxy2,dxy2.T))
-        nsteps=int(max(math.ceil(max(ndxy1,ndxy2)/cs),2))
+        nsteps=int(max(math.ceil(old_div(max(ndxy1,ndxy2),cs)),2))
         h=np.linspace(0,1,nsteps,endpoint=True).reshape((nsteps,1))
         l1=h*dxy1+arr[0]
         l2=h*dxy2+arr[1]

--- a/qc/burn_horse_shoes_lines.py
+++ b/qc/burn_horse_shoes_lines.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from builtins import str
+from builtins import range
 import sys,os,time
 import math
 #import some relevant modules...

--- a/qc/burn_horse_shoes_lines.py
+++ b/qc/burn_horse_shoes_lines.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -17,9 +16,6 @@ from __future__ import division
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 import math
 #import some relevant modules...
@@ -128,7 +124,7 @@ def main(args):
         dxy2=arr[2]-arr[1] # 1 to 2
         ndxy1=np.sqrt(np.dot(dxy1,dxy1.T))
         ndxy2=np.sqrt(np.dot(dxy2,dxy2.T))
-        nsteps=int(max(math.ceil(old_div(max(ndxy1,ndxy2),cs)),2))
+        nsteps=int(max(math.ceil(max(ndxy1,ndxy2)/cs),2))
         h=np.linspace(0,1,nsteps,endpoint=True).reshape((nsteps,1))
         l1=h*dxy1+arr[0]
         l2=h*dxy2+arr[1]

--- a/qc/class_grid.py
+++ b/qc/class_grid.py
@@ -23,6 +23,7 @@ class inside that cell.
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
 import os
 import sys
 import time

--- a/qc/class_grid.py
+++ b/qc/class_grid.py
@@ -23,7 +23,6 @@ class inside that cell.
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
 import os
 import sys
 import time

--- a/qc/class_grid.py
+++ b/qc/class_grid.py
@@ -21,14 +21,15 @@ class inside that cell.
 '''
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
 import time
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
-import dhmqc_constants as constants
-from thatsDEM import pointcloud
+from . import dhmqc_constants as constants
+from .thatsDEM import pointcloud
 
 CELL_SIZE = 1.0
 PROGNAME = os.path.basename(__file__).replace(".pyc", ".py")
@@ -56,7 +57,7 @@ def main(args):
     '''
     try:
         pargs = parser.parse_args(args[1:])
-    except TypeError, error_msg:
+    except TypeError as error_msg:
         print(str(error_msg))
         return 1
     lasname = pargs.las_file
@@ -65,7 +66,7 @@ def main(args):
     print("Running %s on block: %s, %s" % (PROGNAME, kmname, time.asctime()))
     try:
         xll, yll, xlr, yul = constants.tilename_to_extent(kmname)
-    except (ValueError, AttributeError), error_msg:
+    except (ValueError, AttributeError) as error_msg:
         print("Exception: %s" % error_msg)
         print("Bad 1km formatting of las file: %s" % lasname)
         return 1

--- a/qc/classification_check.py
+++ b/qc/classification_check.py
@@ -20,7 +20,6 @@ Determine point cloud classification distribution within a set of input polygons
 
 from __future__ import print_function
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/classification_check.py
+++ b/qc/classification_check.py
@@ -20,6 +20,7 @@ Determine point cloud classification distribution within a set of input polygons
 
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/colorize.py
+++ b/qc/colorize.py
@@ -27,7 +27,6 @@ be in the system path, otherwise the script will fail.
 '''
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import str
 import sys
 import os
 import subprocess

--- a/qc/colorize.py
+++ b/qc/colorize.py
@@ -27,6 +27,7 @@ be in the system path, otherwise the script will fail.
 '''
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import str
 import sys
 import os
 import subprocess

--- a/qc/colorize.py
+++ b/qc/colorize.py
@@ -25,17 +25,19 @@ The coloring is powered by PDAL behind the scenes. The PDAL executable has to
 be in the system path, otherwise the script will fail.
 
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 import os
 import subprocess
 import time
 import json
 
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 import laspy
 
-import dhmqc_constants as constants
-from utils.wmsfetch import get_georef_image_wms
+from . import dhmqc_constants as constants
+from .utils.wmsfetch import get_georef_image_wms
 
 PDAL = 'pdal'
 
@@ -143,7 +145,7 @@ def main(args):
     out_file = os.path.join(pargs.out_dir, os.path.basename(pargs.las_file))
 
     if not os.path.exists(pargs.out_dir):
-        print pargs.out_dir
+        print(pargs.out_dir)
         os.makedirs(os.path.abspath(pargs.out_dir))
 
     # Get image from WMS

--- a/qc/compress.py
+++ b/qc/compress.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/compress.py
+++ b/qc/compress.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -20,11 +22,11 @@ import time
 import subprocess
 
 # Import some relevant modules...
-import dhmqc_constants as constants
+from . import dhmqc_constants as constants
 
 # If you want this script to be included in the test-suite use this subclass.
 # Otherwise argparse.ArgumentParser will be the best choice :-)
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
 # To always get the proper name in usage / help - even when called from a
 # wrapper...

--- a/qc/compress.py
+++ b/qc/compress.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/count_classes.py
+++ b/qc/count_classes.py
@@ -19,7 +19,6 @@ Count classes in a point cloud.
 
 from __future__ import print_function
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/count_classes.py
+++ b/qc/count_classes.py
@@ -19,6 +19,7 @@ Count classes in a point cloud.
 
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/db/db_create_schema.py
+++ b/qc/db/db_create_schema.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,9 +18,9 @@
 import os,sys
 import argparse 
 import psycopg2
-import report
-import db_retrieve_styling
-import db_create_views
+from . import report
+from . import db_retrieve_styling
+from . import db_create_views
 
 parser=argparse.ArgumentParser(description="Create PostGis layers and if needed some views.")
 parser.add_argument("schema",help="The name of the schema to create.")

--- a/qc/db/db_create_views.py
+++ b/qc/db/db_create_views.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -17,8 +19,8 @@ import os,sys
 import argparse 
 import psycopg2
 try:
-    from  pg_connection import PG_CONNECTION
-except Exception,e:
+    from  .pg_connection import PG_CONNECTION
+except Exception as e:
     print("Failed to import pg_connection.py - you need to specify the keyword PG_CONNECTION!")
     print(str(e))
     raise e

--- a/qc/db/db_create_views.py
+++ b/qc/db/db_create_views.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import str
 import os,sys
 import argparse 
 import psycopg2

--- a/qc/db/db_create_views.py
+++ b/qc/db/db_create_views.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
 import os,sys
 import argparse 
 import psycopg2

--- a/qc/db/db_drop_schema.py
+++ b/qc/db/db_drop_schema.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import input
+from builtins import str
 import os,sys
 import argparse
 import psycopg2
@@ -36,7 +38,7 @@ def main(args):
 	PSYCOPGCON = PG_CONNECTION.replace("PG:","").strip()
 	conn = psycopg2.connect(PSYCOPGCON)
 	cur=conn.cursor()
-	s=raw_input("Are you sure you want to drop the schema "+pargs.schema+" ? (Yes/no): ")
+	s=input("Are you sure you want to drop the schema "+pargs.schema+" ? (Yes/no): ")
 	if s.strip().lower().startswith("yes"):
 		MyCommand = "DROP SCHEMA IF EXISTS "+pargs.schema+" CASCADE"
 		cur.execute(MyCommand)

--- a/qc/db/db_drop_schema.py
+++ b/qc/db/db_drop_schema.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -17,8 +19,8 @@ import os,sys
 import argparse
 import psycopg2
 try:
-	from  pg_connection import PG_CONNECTION
-except Exception,e:
+	from  .pg_connection import PG_CONNECTION
+except Exception as e:
 	print("Failed to import pg_connection.py - you need to specify the keyword PG_CONNECTION!")
 	print(str(e))
 	raise e

--- a/qc/db/db_drop_schema.py
+++ b/qc/db/db_drop_schema.py
@@ -15,8 +15,6 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import input
-from builtins import str
 import os,sys
 import argparse
 import psycopg2
@@ -38,7 +36,7 @@ def main(args):
 	PSYCOPGCON = PG_CONNECTION.replace("PG:","").strip()
 	conn = psycopg2.connect(PSYCOPGCON)
 	cur=conn.cursor()
-	s=input("Are you sure you want to drop the schema "+pargs.schema+" ? (Yes/no): ")
+	s=raw_input("Are you sure you want to drop the schema "+pargs.schema+" ? (Yes/no): ")
 	if s.strip().lower().startswith("yes"):
 		MyCommand = "DROP SCHEMA IF EXISTS "+pargs.schema+" CASCADE"
 		cur.execute(MyCommand)

--- a/qc/db/db_reset_schema.py
+++ b/qc/db/db_reset_schema.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/db/db_retrieve_styling.py
+++ b/qc/db/db_retrieve_styling.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
 import os,sys
 import psycopg2
 try:

--- a/qc/db/db_retrieve_styling.py
+++ b/qc/db/db_retrieve_styling.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,8 +18,8 @@
 import os,sys
 import psycopg2
 try:
-	from  pg_connection import PG_CONNECTION
-except Exception,e:
+	from  .pg_connection import PG_CONNECTION
+except Exception as e:
 	print("Failed to import pg_connection.py - you need to specify the keyword PG_CONNECTION!")
 	print(str(e))
 	raise e
@@ -46,7 +48,7 @@ def main(args):
 	conn.commit()	
 	cur2=conn.cursor()
 	for record in cur:
-		print "styling %s" %record
+		print("styling %s" %record)
 		MyCommand2 = """INSERT INTO public.layer_styles (f_table_catalog, f_table_name, f_geometry_column, stylename, styleqml, stylesld, useasdefault, description, owner, ui, update_time) select f_table_catalog, f_table_name, f_geometry_column, stylename, styleqml, stylesld, useasdefault, description, owner, ui, update_time from public.layer_styles where f_table_schema = '%s' and f_table_name = '%s' ;""" %(schema, record[0])
 		cur2.execute(MyCommand2)
 		conn.commit()

--- a/qc/db/db_retrieve_styling.py
+++ b/qc/db/db_retrieve_styling.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import str
 import os,sys
 import psycopg2
 try:

--- a/qc/db/report.py
+++ b/qc/db/report.py
@@ -20,6 +20,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
+from builtins import object
 import os
 import datetime
 

--- a/qc/db/report.py
+++ b/qc/db/report.py
@@ -18,6 +18,7 @@
 # Uses ogr simple feature model to store results in e.g. a database
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import datetime
@@ -25,7 +26,7 @@ import datetime
 from osgeo import ogr, osr, gdal
 
 try:
-    from pg_connection import PG_CONNECTION
+    from .pg_connection import PG_CONNECTION
 except ImportError:
     PG_CONNECTION = None
 

--- a/qc/db/report.py
+++ b/qc/db/report.py
@@ -20,8 +20,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
-from builtins import object
 import os
 import datetime
 

--- a/qc/dem_gen.py
+++ b/qc/dem_gen.py
@@ -20,6 +20,7 @@ Generate DTMs and DSMs from a pointcloud using supporting vector data.
 '''
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import json

--- a/qc/dem_gen.py
+++ b/qc/dem_gen.py
@@ -19,10 +19,7 @@ dem_gen_new.py
 Generate DTMs and DSMs from a pointcloud using supporting vector data.
 '''
 from __future__ import print_function
-from __future__ import division
 
-from builtins import str
-from past.utils import old_div
 import sys
 import os
 import json
@@ -516,10 +513,10 @@ def main(args):
     buf_georef = [grid_buf[0], pargs.cell_size, 0, grid_buf[3], 0, -pargs.cell_size]
 
     #move these to a method in e.g. grid.py
-    ncols = int(ceil(old_div((grid_buf[2] - grid_buf[0]), pargs.cell_size)))
-    nrows = int(ceil(old_div((grid_buf[3] - grid_buf[1]), pargs.cell_size)))
+    ncols = int(ceil((grid_buf[2] - grid_buf[0]) / pargs.cell_size))
+    nrows = int(ceil((grid_buf[3] - grid_buf[1]) / pargs.cell_size))
     assert (extent_buf[:2] < grid_buf[:2]).all()
-    assert modf(old_div((extent[2] - extent[0]), pargs.cell_size))[0] == 0.0
+    assert modf((extent[2] - extent[0]) / pargs.cell_size)[0] == 0.0
 
     if not os.path.exists(pargs.output_dir):
         os.mkdir(pargs.output_dir)

--- a/qc/dem_gen.py
+++ b/qc/dem_gen.py
@@ -19,7 +19,10 @@ dem_gen_new.py
 Generate DTMs and DSMs from a pointcloud using supporting vector data.
 '''
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from past.utils import old_div
 import sys
 import os
 import json
@@ -513,10 +516,10 @@ def main(args):
     buf_georef = [grid_buf[0], pargs.cell_size, 0, grid_buf[3], 0, -pargs.cell_size]
 
     #move these to a method in e.g. grid.py
-    ncols = int(ceil((grid_buf[2] - grid_buf[0]) / pargs.cell_size))
-    nrows = int(ceil((grid_buf[3] - grid_buf[1]) / pargs.cell_size))
+    ncols = int(ceil(old_div((grid_buf[2] - grid_buf[0]), pargs.cell_size)))
+    nrows = int(ceil(old_div((grid_buf[3] - grid_buf[1]), pargs.cell_size)))
     assert (extent_buf[:2] < grid_buf[:2]).all()
-    assert modf((extent[2] - extent[0]) / pargs.cell_size)[0] == 0.0
+    assert modf(old_div((extent[2] - extent[0]), pargs.cell_size))[0] == 0.0
 
     if not os.path.exists(pargs.output_dir):
         os.mkdir(pargs.output_dir)

--- a/qc/density_check.py
+++ b/qc/density_check.py
@@ -17,11 +17,7 @@
 Create density grids from las-files.
 '''
 from __future__ import print_function
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import os
 import sys
 import time
@@ -100,7 +96,7 @@ def main(args):
     kmname = constants.get_tilename(pargs.las_file)
     print("Running %s on block: %s, %s" % (PROGNAME, kmname, time.asctime()))
     cell_size = pargs.cs
-    ncols_f = old_div(TILE_SIZE, cell_size)
+    ncols_f = TILE_SIZE / cell_size
     ncols = int(ncols_f)
     if ncols != ncols_f:
         print("TILE_SIZE: %d must be divisible by cell size..." % (TILE_SIZE))
@@ -134,8 +130,8 @@ def main(args):
 
     las_file = laspy.file.File(lasname, mode='r')
 
-    nx = int(old_div((x_max - x_min), cell_size))
-    ny = int(old_div((y_max - y_min), cell_size))
+    nx = int((x_max - x_min) / cell_size)
+    ny = int((y_max - y_min) / cell_size)
     ds_grid = gdal.GetDriverByName('GTiff').Create(outname, nx, ny, 1, gdal.GDT_Float32)
     georef = (x_min, cell_size, 0, y_max, 0, -cell_size)
     ds_grid.SetGeoTransform(georef)
@@ -163,7 +159,7 @@ def main(args):
             else:
                 I &= np.logical_and(ys >= y_min+j*cell_size, ys <= y_min+(j+1)*cell_size)
 
-            den_grid[ny-j-1][i] = old_div(np.sum(I), (cell_size*cell_size))
+            den_grid[ny-j-1][i] = np.sum(I) / (cell_size*cell_size)
 
     band.WriteArray(den_grid)
     las_file.close()

--- a/qc/density_check.py
+++ b/qc/density_check.py
@@ -17,7 +17,11 @@
 Create density grids from las-files.
 '''
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import os
 import sys
 import time
@@ -96,7 +100,7 @@ def main(args):
     kmname = constants.get_tilename(pargs.las_file)
     print("Running %s on block: %s, %s" % (PROGNAME, kmname, time.asctime()))
     cell_size = pargs.cs
-    ncols_f = TILE_SIZE / cell_size
+    ncols_f = old_div(TILE_SIZE, cell_size)
     ncols = int(ncols_f)
     if ncols != ncols_f:
         print("TILE_SIZE: %d must be divisible by cell size..." % (TILE_SIZE))
@@ -130,8 +134,8 @@ def main(args):
 
     las_file = laspy.file.File(lasname, mode='r')
 
-    nx = int((x_max - x_min) / cell_size)
-    ny = int((y_max - y_min) / cell_size)
+    nx = int(old_div((x_max - x_min), cell_size))
+    ny = int(old_div((y_max - y_min), cell_size))
     ds_grid = gdal.GetDriverByName('GTiff').Create(outname, nx, ny, 1, gdal.GDT_Float32)
     georef = (x_min, cell_size, 0, y_max, 0, -cell_size)
     ds_grid.SetGeoTransform(georef)
@@ -159,7 +163,7 @@ def main(args):
             else:
                 I &= np.logical_and(ys >= y_min+j*cell_size, ys <= y_min+(j+1)*cell_size)
 
-            den_grid[ny-j-1][i] = np.sum(I) / (cell_size*cell_size)
+            den_grid[ny-j-1][i] = old_div(np.sum(I), (cell_size*cell_size))
 
     band.WriteArray(den_grid)
     las_file.close()

--- a/qc/density_check.py
+++ b/qc/density_check.py
@@ -18,6 +18,8 @@ Create density grids from las-files.
 '''
 from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import os
 import sys
 import time

--- a/qc/density_grid.py
+++ b/qc/density_grid.py
@@ -24,6 +24,7 @@ the point classes within the point cloud.
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
 import os
 import sys
 import time

--- a/qc/density_grid.py
+++ b/qc/density_grid.py
@@ -24,7 +24,6 @@ the point classes within the point cloud.
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
 import os
 import sys
 import time

--- a/qc/density_grid.py
+++ b/qc/density_grid.py
@@ -22,16 +22,17 @@ the point classes within the point cloud.
 '''
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
 import time
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
 import numpy as np
 
-import dhmqc_constants as constants
-from thatsDEM import pointcloud
+from . import dhmqc_constants as constants
+from .thatsDEM import pointcloud
 
 CELL_SIZE = 1.0
 PROGNAME = os.path.basename(__file__).replace(".pyc", ".py")
@@ -68,7 +69,7 @@ def main(args):
     '''
     try:
         pargs = parser.parse_args(args[1:])
-    except TypeError, error_msg:
+    except TypeError as error_msg:
         print(str(error_msg))
         return 1
 
@@ -79,7 +80,7 @@ def main(args):
 
     try:
         xll, yll, xlr, yul = constants.tilename_to_extent(kmname)
-    except (ValueError, AttributeError), error_msg:
+    except (ValueError, AttributeError) as error_msg:
         print("Exception: %s" % error_msg)
         print("Bad 1km formatting of las file: %s" % lasname)
         return 1

--- a/qc/dhmqc_constants.py
+++ b/qc/dhmqc_constants.py
@@ -1,3 +1,4 @@
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -13,6 +14,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 # This is kind of a 'project' specific constants file
+from past.utils import old_div
 import os
 import glob
 
@@ -77,8 +79,8 @@ def tilename_to_extent(tilename, return_wkt=False):
 	return xt
 
 def point_to_tilename(x,y):
-	E = int(x/tile_size)
-	N = int(y/tile_size)
+	E = int(old_div(x,tile_size))
+	N = int(old_div(y,tile_size))
 	return "1km_{0:d}_{1:d}".format(N, E)
 
 def tilename_to_index(tilename):
@@ -112,8 +114,8 @@ def get_vector_tile(basedir, lasname, ext = ".shp", simple_layout = False):
 	E = int(tokens[i+2])
 
 	if not simple_layout:
-		N10 = int(N/10)
-		E10 = int(E/10)
+		N10 = int(old_div(N,10))
+		E10 = int(old_div(E,10))
 		km10name = "*{0:d}_{1:d}".format(N10,E10)
 		dirs = glob.glob(os.path.join(basedir, km10name))
 		if len(dirs)>0:

--- a/qc/dhmqc_constants.py
+++ b/qc/dhmqc_constants.py
@@ -1,4 +1,3 @@
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -14,7 +13,6 @@ from __future__ import division
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 # This is kind of a 'project' specific constants file
-from past.utils import old_div
 import os
 import glob
 
@@ -79,8 +77,8 @@ def tilename_to_extent(tilename, return_wkt=False):
 	return xt
 
 def point_to_tilename(x,y):
-	E = int(old_div(x,tile_size))
-	N = int(old_div(y,tile_size))
+	E = int(x/tile_size)
+	N = int(y/tile_size)
 	return "1km_{0:d}_{1:d}".format(N, E)
 
 def tilename_to_index(tilename):
@@ -114,8 +112,8 @@ def get_vector_tile(basedir, lasname, ext = ".shp", simple_layout = False):
 	E = int(tokens[i+2])
 
 	if not simple_layout:
-		N10 = int(old_div(N,10))
-		E10 = int(old_div(E,10))
+		N10 = int(N/10)
+		E10 = int(E/10)
 		km10name = "*{0:d}_{1:d}".format(N10,E10)
 		dirs = glob.glob(os.path.join(basedir, km10name))
 		if len(dirs)>0:

--- a/qc/dvr90_wrapper.py
+++ b/qc/dvr90_wrapper.py
@@ -18,6 +18,7 @@ DVR90 wrapper. Applies geoid offsets to las-files in ellipsoidal heights.
 '''
 from __future__ import print_function
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/dvr90_wrapper.py
+++ b/qc/dvr90_wrapper.py
@@ -18,7 +18,6 @@ DVR90 wrapper. Applies geoid offsets to las-files in ellipsoidal heights.
 '''
 from __future__ import print_function
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/find_holes.py
+++ b/qc/find_holes.py
@@ -14,6 +14,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 import os
@@ -21,12 +22,12 @@ import time
 import json
 from osgeo import osr
 
-from thatsDEM import pointcloud, vector_io, array_geometry, grid
-from db import report
+from .thatsDEM import pointcloud, vector_io, array_geometry, grid
+from .db import report
 import numpy as np
 import scipy.ndimage as image
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser
 
 # If you want this script to be included in the test-suite use this
 # subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
@@ -167,7 +168,7 @@ def cluster(pc, cs, n_expand=2):
 def main(args):
     try:
         pargs = parser.parse_args(args[1:])
-    except Exception, error_msg:
+    except Exception as error_msg:
         print(str(error_msg))
         return 1
 
@@ -176,7 +177,7 @@ def main(args):
 
     try:
         extent = constants.tilename_to_extent(kmname)
-    except Exception, error_msg:
+    except Exception as error_msg:
         print("Bad tilename:")
         print(str(error_msg))
         return 1

--- a/qc/find_holes.py
+++ b/qc/find_holes.py
@@ -16,6 +16,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
 import sys
 import os
 import time

--- a/qc/find_holes.py
+++ b/qc/find_holes.py
@@ -15,11 +15,7 @@
 #
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys
 import os
 import time
@@ -150,9 +146,9 @@ def cluster(pc, cs, n_expand=2):
     # cluster according to some scheme and return a segmentizeed grid
     x1, y1, x2, y2 = pc.get_bounds()
     georef = [x1 - cs, cs, 0, y2 + cs, 0, -cs]
-    ncols = int(old_div((x2 - georef[0]), cs)) + 1
-    nrows = int(old_div((georef[3] - y1), cs)) + 1
-    JI = (old_div((pc.xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int64)
+    ncols = int((x2 - georef[0]) / cs) + 1
+    nrows = int((georef[3] - y1) / cs) + 1
+    JI = ((pc.xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int64)
     assert (JI >= 0).all()
     assert (JI < (ncols, nrows)).all()
     M = np.zeros((nrows, ncols), dtype=np.bool)
@@ -225,8 +221,8 @@ def main(args):
     print("# potential fill points: %d" % pc_pot.get_size())
     cs_burn = CS_BURN  # use a global
     geo_ref = [extent[0], cs_burn, 0, extent[3], 0, -cs_burn]
-    ncols = int(old_div((extent[2] - extent[0]), cs_burn))
-    nrows = int(old_div((extent[3] - extent[1]), cs_burn))
+    ncols = int((extent[2] - extent[0]) / cs_burn)
+    nrows = int((extent[3] - extent[1]) / cs_burn)
     assert((cs_burn * ncols + extent[0]) == extent[2])
     exclude_mask = np.zeros((nrows, ncols), dtype=np.bool)
     for sql in fargs["EXCLUDE_SQL"]:
@@ -267,8 +263,8 @@ def main(args):
     if pc_pot.get_size() > 0:
         cs = CS_MESH  # use a global
         geo_ref = [extent[0], cs, 0, extent[3], 0, -cs]
-        ncols = int(old_div((extent[2] - extent[0]), cs))
-        nrows = int(old_div((extent[3] - extent[1]), cs))
+        ncols = int((extent[2] - extent[0]) / cs)
+        nrows = int((extent[3] - extent[1]) / cs)
         assert((cs * ncols + extent[0]) == extent[2])
         pc_ref.sort_spatially(FRAD_IDW)
         pc.sort_spatially(FRAD_IDW)
@@ -349,8 +345,8 @@ def main(args):
         pc.extend(pc_pot, least_common=True)
         cs = CS_FINAL_GRID  # use a global
         geo_ref = [extent[0], cs, 0, extent[3], 0, -cs]
-        ncols = int(old_div((extent[2] - extent[0]), cs))
-        nrows = int(old_div((extent[3] - extent[1]), cs))
+        ncols = int((extent[2] - extent[0]) / cs)
+        nrows = int((extent[3] - extent[1]) / cs)
         assert((cs * ncols + extent[0]) == extent[2])
         pc.sort_spatially(FRAD_FINAL_GRID)
         xy = pointcloud.mesh_as_points((nrows, ncols), geo_ref)

--- a/qc/find_holes.py
+++ b/qc/find_holes.py
@@ -15,7 +15,11 @@
 #
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys
 import os
 import time
@@ -146,9 +150,9 @@ def cluster(pc, cs, n_expand=2):
     # cluster according to some scheme and return a segmentizeed grid
     x1, y1, x2, y2 = pc.get_bounds()
     georef = [x1 - cs, cs, 0, y2 + cs, 0, -cs]
-    ncols = int((x2 - georef[0]) / cs) + 1
-    nrows = int((georef[3] - y1) / cs) + 1
-    JI = ((pc.xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int64)
+    ncols = int(old_div((x2 - georef[0]), cs)) + 1
+    nrows = int(old_div((georef[3] - y1), cs)) + 1
+    JI = (old_div((pc.xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int64)
     assert (JI >= 0).all()
     assert (JI < (ncols, nrows)).all()
     M = np.zeros((nrows, ncols), dtype=np.bool)
@@ -221,8 +225,8 @@ def main(args):
     print("# potential fill points: %d" % pc_pot.get_size())
     cs_burn = CS_BURN  # use a global
     geo_ref = [extent[0], cs_burn, 0, extent[3], 0, -cs_burn]
-    ncols = int((extent[2] - extent[0]) / cs_burn)
-    nrows = int((extent[3] - extent[1]) / cs_burn)
+    ncols = int(old_div((extent[2] - extent[0]), cs_burn))
+    nrows = int(old_div((extent[3] - extent[1]), cs_burn))
     assert((cs_burn * ncols + extent[0]) == extent[2])
     exclude_mask = np.zeros((nrows, ncols), dtype=np.bool)
     for sql in fargs["EXCLUDE_SQL"]:
@@ -263,8 +267,8 @@ def main(args):
     if pc_pot.get_size() > 0:
         cs = CS_MESH  # use a global
         geo_ref = [extent[0], cs, 0, extent[3], 0, -cs]
-        ncols = int((extent[2] - extent[0]) / cs)
-        nrows = int((extent[3] - extent[1]) / cs)
+        ncols = int(old_div((extent[2] - extent[0]), cs))
+        nrows = int(old_div((extent[3] - extent[1]), cs))
         assert((cs * ncols + extent[0]) == extent[2])
         pc_ref.sort_spatially(FRAD_IDW)
         pc.sort_spatially(FRAD_IDW)
@@ -345,8 +349,8 @@ def main(args):
         pc.extend(pc_pot, least_common=True)
         cs = CS_FINAL_GRID  # use a global
         geo_ref = [extent[0], cs, 0, extent[3], 0, -cs]
-        ncols = int((extent[2] - extent[0]) / cs)
-        nrows = int((extent[3] - extent[1]) / cs)
+        ncols = int(old_div((extent[2] - extent[0]), cs))
+        nrows = int(old_div((extent[3] - extent[1]), cs))
         assert((cs * ncols + extent[0]) == extent[2])
         pc.sort_spatially(FRAD_FINAL_GRID)
         xy = pointcloud.mesh_as_points((nrows, ncols), geo_ref)

--- a/qc/find_planes.py
+++ b/qc/find_planes.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -15,8 +14,6 @@ from __future__ import division
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from builtins import range
-from past.utils import old_div
 from math import degrees,radians,acos,sqrt,cos,sin,atan,tan
 import math
 from qc.thatsDEM import array_geometry
@@ -68,8 +65,8 @@ def find_planar_pairs(planes):
             p2=planes[j]
             g_score=((p1[0]+p2[0])**2+(p1[1]+p2[1])**2)+2.0/(p1[-1]+p2[-1]) #bonus for being close, bonus for being steep
             pop=(p1[-2]+p2[-2])
-            score=old_div(g_score,pop)
-            if score<best_score or ((old_div(best_score,score))>0.85 and old_div(pop,best_pop)>1.5):
+            score=g_score/pop
+            if score<best_score or ((best_score/score)>0.85 and pop/best_pop>1.5):
                 pair=(i,j)
                 best_score=score
                 best_pop=pop
@@ -85,9 +82,9 @@ def find_planar_pairs(planes):
 def find_horisontal_planes(z,look_lim=0.2, bin_size=0.2):
     z1=z.min()
     z2=z.max()
-    n=max(int(old_div(np.round(z2-z1),bin_size)),1)
+    n=max(int(np.round(z2-z1)/bin_size),1)
     h,bins=np.histogram(z,n)
-    h=old_div(h.astype(np.float64),z.size)
+    h=h.astype(np.float64)/z.size
 
     #TODO: real clustering
     I=np.where(h>=look_lim)[0]  #the bins that are above fraction look_lim
@@ -112,10 +109,10 @@ def search(v1,v2,r1,r2,xy,z,look_lim=0.1,bin_size=0.2,steps=15):
             b=r*sin(v)  #y
             alpha=degrees(atan(r))  #the angle relative to vertical
             nn=sqrt(r**2+1)
-            c=old_div((z-a*xy[:,0]-b*xy[:,1]),nn) #normalise to get real projection onto axis...
+            c=(z-a*xy[:,0]-b*xy[:,1])/nn #normalise to get real projection onto axis...
             zs,ns=array_geometry.moving_bins(c,bin_size*0.5)
             i=np.argmax(ns)   #the most
-            f=old_div(ns[i],(float(zs.size)))
+            f=ns[i]/(float(zs.size))
 
             if f>look_lim: #and h[i]>3*h.mean(): #this one fucks it up...
                 c_m=zs[i]*nn
@@ -141,10 +138,10 @@ def cluster(pc,steps1=15,steps2=20): #number of steps affect running time and pr
         return []
 
     fmax,found=search(0,2*math.pi,R1,R2,xy,z,0.2,bin_size=0.22,steps=steps1)
-    vrad=old_div(2*math.pi,steps1*0.85)
+    vrad=2*math.pi/steps1*0.85
     rrad=0.85*(R2-R1)/steps1
-    vstep2=old_div(vrad,steps2)
-    rstep2=old_div(rrad,steps2)
+    vstep2=vrad/steps2
+    rstep2=rrad/steps2
     print("Initial search resulted in %d planes." %len(found))
     final_candidates={}
     if len(found)>0:
@@ -178,5 +175,5 @@ def cluster(pc,steps1=15,steps2=20): #number of steps affect running time and pr
                 z1=a*xy[:,0]+b*xy[:,1]+f[2]
                 plot3d(xy,z,z1)
 
-    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in list(final_candidates.values())]
+    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in final_candidates.values()]
     return toab

--- a/qc/find_planes.py
+++ b/qc/find_planes.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -14,6 +15,8 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from builtins import range
+from past.utils import old_div
 from math import degrees,radians,acos,sqrt,cos,sin,atan,tan
 import math
 from qc.thatsDEM import array_geometry
@@ -65,8 +68,8 @@ def find_planar_pairs(planes):
             p2=planes[j]
             g_score=((p1[0]+p2[0])**2+(p1[1]+p2[1])**2)+2.0/(p1[-1]+p2[-1]) #bonus for being close, bonus for being steep
             pop=(p1[-2]+p2[-2])
-            score=g_score/pop
-            if score<best_score or ((best_score/score)>0.85 and pop/best_pop>1.5):
+            score=old_div(g_score,pop)
+            if score<best_score or ((old_div(best_score,score))>0.85 and old_div(pop,best_pop)>1.5):
                 pair=(i,j)
                 best_score=score
                 best_pop=pop
@@ -82,9 +85,9 @@ def find_planar_pairs(planes):
 def find_horisontal_planes(z,look_lim=0.2, bin_size=0.2):
     z1=z.min()
     z2=z.max()
-    n=max(int(np.round(z2-z1)/bin_size),1)
+    n=max(int(old_div(np.round(z2-z1),bin_size)),1)
     h,bins=np.histogram(z,n)
-    h=h.astype(np.float64)/z.size
+    h=old_div(h.astype(np.float64),z.size)
 
     #TODO: real clustering
     I=np.where(h>=look_lim)[0]  #the bins that are above fraction look_lim
@@ -109,10 +112,10 @@ def search(v1,v2,r1,r2,xy,z,look_lim=0.1,bin_size=0.2,steps=15):
             b=r*sin(v)  #y
             alpha=degrees(atan(r))  #the angle relative to vertical
             nn=sqrt(r**2+1)
-            c=(z-a*xy[:,0]-b*xy[:,1])/nn #normalise to get real projection onto axis...
+            c=old_div((z-a*xy[:,0]-b*xy[:,1]),nn) #normalise to get real projection onto axis...
             zs,ns=array_geometry.moving_bins(c,bin_size*0.5)
             i=np.argmax(ns)   #the most
-            f=ns[i]/(float(zs.size))
+            f=old_div(ns[i],(float(zs.size)))
 
             if f>look_lim: #and h[i]>3*h.mean(): #this one fucks it up...
                 c_m=zs[i]*nn
@@ -138,10 +141,10 @@ def cluster(pc,steps1=15,steps2=20): #number of steps affect running time and pr
         return []
 
     fmax,found=search(0,2*math.pi,R1,R2,xy,z,0.2,bin_size=0.22,steps=steps1)
-    vrad=2*math.pi/steps1*0.85
+    vrad=old_div(2*math.pi,steps1*0.85)
     rrad=0.85*(R2-R1)/steps1
-    vstep2=vrad/steps2
-    rstep2=rrad/steps2
+    vstep2=old_div(vrad,steps2)
+    rstep2=old_div(rrad,steps2)
     print("Initial search resulted in %d planes." %len(found))
     final_candidates={}
     if len(found)>0:
@@ -175,5 +178,5 @@ def cluster(pc,steps1=15,steps2=20): #number of steps affect running time and pr
                 z1=a*xy[:,0]+b*xy[:,1]+f[2]
                 plot3d(xy,z,z1)
 
-    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in final_candidates.values()]
+    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in list(final_candidates.values())]
     return toab

--- a/qc/find_planes.py
+++ b/qc/find_planes.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from builtins import range
 from math import degrees,radians,acos,sqrt,cos,sin,atan,tan
 import math
 from qc.thatsDEM import array_geometry
@@ -175,5 +176,5 @@ def cluster(pc,steps1=15,steps2=20): #number of steps affect running time and pr
                 z1=a*xy[:,0]+b*xy[:,1]+f[2]
                 plot3d(xy,z,z1)
 
-    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in final_candidates.values()]
+    toab=[(f[1]*cos(f[0]),f[1]*sin(f[0]),f[2],f[3],f[4]) for f in list(final_candidates.values())]
     return toab

--- a/qc/find_planes.py
+++ b/qc/find_planes.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/hillshade.py
+++ b/qc/hillshade.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import grid

--- a/qc/hillshade.py
+++ b/qc/hillshade.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -15,13 +17,13 @@
 #
 import sys,os,time
 #import some relevant modules...
-from thatsDEM import grid
-import dhmqc_constants as constants
+from .thatsDEM import grid
+from . import dhmqc_constants as constants
 import numpy as np
 import scipy.ndimage as im
 from osgeo import gdal
 import sqlite3 as db
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 #To always get the proper name in usage / help - even when called from a wrapper...
 progname=os.path.basename(__file__).replace(".pyc",".py")
 #Argument handling - if module has a parser attributte it will be used to check arguments in wrapper script.
@@ -89,7 +91,7 @@ def get_extended_tile(tile_db,tilename):
 def main(args):
     try:
         pargs=parser.parse_args(args[1:])
-    except Exception,e:
+    except Exception as e:
         print(str(e))
         return 1
     kmname=constants.get_tilename(pargs.tile_name)

--- a/qc/hillshade.py
+++ b/qc/hillshade.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import str
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import grid

--- a/qc/las2polygons.py
+++ b/qc/las2polygons.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -19,9 +18,6 @@ from __future__ import division
 ## Polygonize building points from LAS
 ## Includes a 4 liner fast density grid creation!! Nice :-)
 ##########################
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import os,sys
 import time
 import numpy as np
@@ -101,7 +97,7 @@ def main(args):
 	ncols=TILE_SIZE//cs
 	nrows=ncols
 	georef=[xul,cs,0,yul,0,-cs]
-	arr_coords=(old_div((pc.xy-(georef[0],georef[3])),(georef[1],georef[5]))).astype(np.int32)
+	arr_coords=((pc.xy-(georef[0],georef[3]))/(georef[1],georef[5])).astype(np.int32)
 	M=np.logical_and(arr_coords[:,0]>=0, arr_coords[:,0]<ncols)
 	M&=np.logical_and(arr_coords[:,1]>=0,arr_coords[:,1]<nrows)
 	arr_coords=arr_coords[M]

--- a/qc/las2polygons.py
+++ b/qc/las2polygons.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -18,6 +19,9 @@ from __future__ import print_function
 ## Polygonize building points from LAS
 ## Includes a 4 liner fast density grid creation!! Nice :-)
 ##########################
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import os,sys
 import time
 import numpy as np
@@ -97,7 +101,7 @@ def main(args):
 	ncols=TILE_SIZE//cs
 	nrows=ncols
 	georef=[xul,cs,0,yul,0,-cs]
-	arr_coords=((pc.xy-(georef[0],georef[3]))/(georef[1],georef[5])).astype(np.int32)
+	arr_coords=(old_div((pc.xy-(georef[0],georef[3])),(georef[1],georef[5]))).astype(np.int32)
 	M=np.logical_and(arr_coords[:,0]>=0, arr_coords[:,0]<ncols)
 	M&=np.logical_and(arr_coords[:,1]>=0,arr_coords[:,1]<nrows)
 	arr_coords=arr_coords[M]

--- a/qc/las2polygons.py
+++ b/qc/las2polygons.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 ## Polygonize building points from LAS
 ## Includes a 4 liner fast density grid creation!! Nice :-)
 ##########################
+from builtins import str
+from builtins import range
 import os,sys
 import time
 import numpy as np

--- a/qc/las2polygons.py
+++ b/qc/las2polygons.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/levitating_plants.py
+++ b/qc/levitating_plants.py
@@ -28,6 +28,7 @@ simlk, oct. 2014
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/levitating_plants.py
+++ b/qc/levitating_plants.py
@@ -28,7 +28,6 @@ simlk, oct. 2014
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/levitating_plants.py
+++ b/qc/levitating_plants.py
@@ -26,6 +26,7 @@ ground component, we need to do some morphology.
 simlk, oct. 2014
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 import os
@@ -33,9 +34,9 @@ import time
 import numpy as np
 import scipy.ndimage as im
 
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser
-from thatsDEM import pointcloud, array_geometry
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser
+from .thatsDEM import pointcloud, array_geometry
 
 # hmmm - can stuff below bridges be floating - no, guess not.
 cut_ground = [constants.water, constants.terrain, constants.bridge]
@@ -113,7 +114,7 @@ def main(args):
     '''
     try:
         pargs = parser.parse_args(args[1:])
-    except Exception, error_msg:
+    except Exception as error_msg:
         print(str(error_msg))
         return 1
 
@@ -137,7 +138,7 @@ def main(args):
 
     try:
         x1, y1, x2, y2 = constants.tilename_to_extent(kmname)
-    except Exception, e:
+    except Exception as e:
         print("Exception: %s" % str(e))
         print("Bad 1km formatting of las file: %s" % lasname)
         return 1

--- a/qc/pc_repair_man.py
+++ b/qc/pc_repair_man.py
@@ -35,12 +35,6 @@ from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from . import dhmqc_constants as constants
 from qc.utils.osutils import ArgumentParser, run_command
 
-# Ensures compatibility with both Python 2.7 and 3.x. Once 2.x support can be
-# dropped, a search-and-replace of "unicode" -> "str" may be done on this
-# module.
-if sys.version_info[0] >= 3:
-    str = str
-
 PROGNAME = os.path.basename(__file__).replace('.pyc', '.py')
 CS_BURN = 0.4
 CS_BURN_BUILD = 0.2  # finer granularity - consider shrinking slightly

--- a/qc/pc_repair_man.py
+++ b/qc/pc_repair_man.py
@@ -37,12 +37,6 @@ from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from . import dhmqc_constants as constants
 from qc.utils.osutils import ArgumentParser, run_command
 
-# Ensures compatibility with both Python 2.7 and 3.x. Once 2.x support can be
-# dropped, a search-and-replace of "unicode" -> "str" may be done on this
-# module.
-if sys.version_info[0] >= 3:
-    str = str
-
 PROGNAME = os.path.basename(__file__).replace('.pyc', '.py')
 CS_BURN = 0.4
 CS_BURN_BUILD = 0.2  # finer granularity - consider shrinking slightly

--- a/qc/pc_repair_man.py
+++ b/qc/pc_repair_man.py
@@ -18,6 +18,9 @@ or filling data voids with data from another datasource.
 '''
 from __future__ import print_function
 
+from builtins import str
+from builtins import range
+from builtins import object
 import sys
 import os
 import time
@@ -36,7 +39,7 @@ from qc.utils.osutils import ArgumentParser, run_command
 # dropped, a search-and-replace of "unicode" -> "str" may be done on this
 # module.
 if sys.version_info[0] >= 3:
-    unicode = str
+    str = str
 
 PROGNAME = os.path.basename(__file__).replace('.pyc', '.py')
 CS_BURN = 0.4
@@ -151,7 +154,7 @@ class FillHoles(BaseRepairMan):
     '''
     Repairer class that fills data voids with data from another source.
     '''
-    keys = {'cstr': unicode, 'sql': str, 'path': unicode}
+    keys = {'cstr': str, 'sql': str, 'path': str}
 
     def __str__(self):
         return 'FillHoles'
@@ -206,7 +209,7 @@ class FillHoles(BaseRepairMan):
 
         i_prev = 0
         for pc_ in feature_pointclouds:
-            I = range(i_prev, i_prev+pc_.size)
+            I = list(range(i_prev, i_prev+pc_.size))
             i_prev += pc_.size
 
             # Usually laspy would do the scaling for us, but since we are
@@ -226,7 +229,7 @@ class BirdsAndWires(BaseRepairMan):
     birds and wires, as high noise.
     '''
     # Must use the original file in same h-system. Will otherwise f*** up...
-    keys = {'cstr': unicode, 'sql_exclude': list, 'sql_include': dict, 'exclude_all': bool}
+    keys = {'cstr': str, 'sql_exclude': list, 'sql_include': dict, 'exclude_all': bool}
 
     def __str__(self):
         return 'BirdsAndWires'
@@ -285,7 +288,7 @@ class Spikes(BaseRepairMan):
     '''
     Repairer class that reclassifies spikes as noise.
     '''
-    keys = {'cstr': unicode, 'sql': str}
+    keys = {'cstr': str, 'sql': str}
 
     def __str__(self):
         return 'RepairSpikes'
@@ -314,7 +317,7 @@ class CleanBuildings(BaseRepairMan):
     inside buildings as custom classes 18 (terrain in building) and
     19 (vegetation in building).
     '''
-    keys = {'cstr': unicode, 'sql': str}
+    keys = {'cstr': str, 'sql': str}
 
     def __str__(self):
         return 'CleanBuildings'
@@ -338,7 +341,7 @@ class CleanBuildings(BaseRepairMan):
             return
 
         pc = pointcloud.fromLaspy(self.las)
-        pc = pc.cut_to_class(BUILDING_RECLASS.keys())
+        pc = pc.cut_to_class(list(BUILDING_RECLASS.keys()))
         pc = pc.cut_to_grid_mask(build_mask, georef)
 
         if pc.size <= 0:

--- a/qc/pc_repair_man.py
+++ b/qc/pc_repair_man.py
@@ -37,6 +37,12 @@ from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from . import dhmqc_constants as constants
 from qc.utils.osutils import ArgumentParser, run_command
 
+# Ensures compatibility with both Python 2.7 and 3.x. Once 2.x support can be
+# dropped, a search-and-replace of "unicode" -> "str" may be done on this
+# module.
+if sys.version_info[0] >= 3:
+    str = str
+
 PROGNAME = os.path.basename(__file__).replace('.pyc', '.py')
 CS_BURN = 0.4
 CS_BURN_BUILD = 0.2  # finer granularity - consider shrinking slightly

--- a/qc/pc_repair_man.py
+++ b/qc/pc_repair_man.py
@@ -17,12 +17,7 @@ Manipulate pointcloud data by either reclassifying points, fixing timestamps
 or filling data voids with data from another datasource.
 '''
 from __future__ import print_function
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
-from builtins import object
 import sys
 import os
 import time
@@ -41,7 +36,7 @@ from qc.utils.osutils import ArgumentParser, run_command
 # dropped, a search-and-replace of "unicode" -> "str" may be done on this
 # module.
 if sys.version_info[0] >= 3:
-    str = str
+    unicode = str
 
 PROGNAME = os.path.basename(__file__).replace('.pyc', '.py')
 CS_BURN = 0.4
@@ -156,7 +151,7 @@ class FillHoles(BaseRepairMan):
     '''
     Repairer class that fills data voids with data from another source.
     '''
-    keys = {'cstr': str, 'sql': str, 'path': str}
+    keys = {'cstr': unicode, 'sql': str, 'path': unicode}
 
     def __str__(self):
         return 'FillHoles'
@@ -211,15 +206,15 @@ class FillHoles(BaseRepairMan):
 
         i_prev = 0
         for pc_ in feature_pointclouds:
-            I = list(range(i_prev, i_prev+pc_.size))
+            I = range(i_prev, i_prev+pc_.size)
             i_prev += pc_.size
 
             # Usually laspy would do the scaling for us, but since we are
             # manipulating the raw data directly we need to convert
             # coordinates to properly scaled integers
-            holes['point']['X'][I] = old_div((pc_.xy[:, 0] - self.offset[0]), self.scale[0])
-            holes['point']['Y'][I] = old_div((pc_.xy[:, 1] - self.offset[1]), self.scale[1])
-            holes['point']['Z'][I] = old_div((pc_.z - self.offset[2]), self.scale[2])
+            holes['point']['X'][I] = (pc_.xy[:, 0] - self.offset[0]) / self.scale[0]
+            holes['point']['Y'][I] = (pc_.xy[:, 1] - self.offset[1]) / self.scale[1]
+            holes['point']['Z'][I] = (pc_.z - self.offset[2]) / self.scale[2]
 
         xyc = np.empty((0,3),dtype=np.float64)
         return (np.append(points, holes), xyc)
@@ -231,7 +226,7 @@ class BirdsAndWires(BaseRepairMan):
     birds and wires, as high noise.
     '''
     # Must use the original file in same h-system. Will otherwise f*** up...
-    keys = {'cstr': str, 'sql_exclude': list, 'sql_include': dict, 'exclude_all': bool}
+    keys = {'cstr': unicode, 'sql_exclude': list, 'sql_include': dict, 'exclude_all': bool}
 
     def __str__(self):
         return 'BirdsAndWires'
@@ -244,8 +239,8 @@ class BirdsAndWires(BaseRepairMan):
 
         pc = pointcloud.fromBinary(path)
         georef = [self.extent[0], CS_BURN, 0, self.extent[3], 0, -CS_BURN]
-        ncols = int(old_div((self.extent[2] - self.extent[0]), CS_BURN))
-        nrows = int(old_div((self.extent[3] - self.extent[1]), CS_BURN))
+        ncols = int((self.extent[2] - self.extent[0]) / CS_BURN)
+        nrows = int((self.extent[3] - self.extent[1]) / CS_BURN)
 
         assert (ncols * CS_BURN + self.extent[0]) == self.extent[2]
         assert (nrows * CS_BURN + self.extent[1]) == self.extent[3]
@@ -290,7 +285,7 @@ class Spikes(BaseRepairMan):
     '''
     Repairer class that reclassifies spikes as noise.
     '''
-    keys = {'cstr': str, 'sql': str}
+    keys = {'cstr': unicode, 'sql': str}
 
     def __str__(self):
         return 'RepairSpikes'
@@ -319,15 +314,15 @@ class CleanBuildings(BaseRepairMan):
     inside buildings as custom classes 18 (terrain in building) and
     19 (vegetation in building).
     '''
-    keys = {'cstr': str, 'sql': str}
+    keys = {'cstr': unicode, 'sql': str}
 
     def __str__(self):
         return 'CleanBuildings'
 
     def repair(self, points):
         georef = [self.extent[0], CS_BURN_BUILD, 0, self.extent[3], 0, -CS_BURN_BUILD]
-        ncols = int(old_div((self.extent[2] - self.extent[0]), CS_BURN_BUILD))
-        nrows = int(old_div((self.extent[3] - self.extent[1]), CS_BURN_BUILD))
+        ncols = int((self.extent[2] - self.extent[0]) / CS_BURN_BUILD)
+        nrows = int((self.extent[3] - self.extent[1]) / CS_BURN_BUILD)
 
         assert (ncols * CS_BURN_BUILD + self.extent[0]) == self.extent[2]
         assert (nrows * CS_BURN_BUILD + self.extent[1]) == self.extent[3]
@@ -343,7 +338,7 @@ class CleanBuildings(BaseRepairMan):
             return
 
         pc = pointcloud.fromLaspy(self.las)
-        pc = pc.cut_to_class(list(BUILDING_RECLASS.keys()))
+        pc = pc.cut_to_class(BUILDING_RECLASS.keys())
         pc = pc.cut_to_grid_mask(build_mask, georef)
 
         if pc.size <= 0:

--- a/qc/point_distance.py
+++ b/qc/point_distance.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -15,6 +16,8 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
+from past.utils import old_div
 import os,sys
 import time
 import subprocess
@@ -65,7 +68,7 @@ def main(args):
 		return 1
 	print("Running %s on block: %s, %s" %(progname,kmname,time.asctime()))
 	cs=pargs.cs
-	ncols_f=TILE_SIZE/cs
+	ncols_f=old_div(TILE_SIZE,cs)
 	ncols=int(ncols_f)
 	nrows=ncols  #tiles are square (for now)
 	if ncols!=ncols_f:

--- a/qc/point_distance.py
+++ b/qc/point_distance.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,8 +15,6 @@ from __future__ import division
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import str
-from past.utils import old_div
 import os,sys
 import time
 import subprocess
@@ -68,7 +65,7 @@ def main(args):
 		return 1
 	print("Running %s on block: %s, %s" %(progname,kmname,time.asctime()))
 	cs=pargs.cs
-	ncols_f=old_div(TILE_SIZE,cs)
+	ncols_f=TILE_SIZE/cs
 	ncols=int(ncols_f)
 	nrows=ncols  #tiles are square (for now)
 	if ncols!=ncols_f:

--- a/qc/point_distance.py
+++ b/qc/point_distance.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
 import os,sys
 import time
 import subprocess

--- a/qc/point_distance.py
+++ b/qc/point_distance.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -18,9 +20,9 @@ import time
 import subprocess
 import numpy as np
 from osgeo import osr
-import dhmqc_constants as constants
-from thatsDEM import pointcloud,grid
-from utils.osutils import ArgumentParser  
+from . import dhmqc_constants as constants
+from .thatsDEM import pointcloud,grid
+from .utils.osutils import ArgumentParser  
 import math
 SRS=osr.SpatialReference()
 SRS.ImportFromEPSG(constants.EPSG_CODE)
@@ -50,14 +52,14 @@ def usage():
 def main(args):
 	try:
 		pargs=parser.parse_args(args[1:])
-	except Exception,e:
+	except Exception as e:
 		print(str(e))
 		return 1
 	lasname=pargs.las_file
 	kmname=constants.get_tilename(lasname)
 	try:
 		extent=constants.tilename_to_extent(kmname)
-	except Exception,e:
+	except Exception as e:
 		print("Bad tilename:")
 		print(str(e))
 		return 1

--- a/qc/pointcloud_diff.py
+++ b/qc/pointcloud_diff.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
 import sys,os,time
 import numpy as np
 from osgeo import ogr

--- a/qc/pointcloud_diff.py
+++ b/qc/pointcloud_diff.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,10 +18,10 @@
 import sys,os,time
 import numpy as np
 from osgeo import ogr
-from thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
-from db import report
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser
+from .thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
+from .db import report
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser
 
 #path to geoid 
 GEOID_GRID=os.path.join(os.path.dirname(__file__),"..","data","dkgeoid13b.utm32")
@@ -75,7 +77,7 @@ def check_points(dz):
 def main(args):
 	try:
 		pargs=parser.parse_args(args[1:])
-	except Exception,e:
+	except Exception as e:
 		print(str(e))
 		return 1
 	#standard dhmqc idioms....#
@@ -85,7 +87,7 @@ def main(args):
 	print("Running %s on block: %s, %s" %(os.path.basename(args[0]),kmname,time.asctime()))
 	try:
 		xul,yll,xur,yul=constants.tilename_to_extent(kmname)
-	except Exception,e:
+	except Exception as e:
 		print("Exception: %s" %str(e))
 		print("Bad 1km formatting of las file: %s" %lasname)
 		return 1

--- a/qc/pointcloud_diff.py
+++ b/qc/pointcloud_diff.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -15,6 +16,8 @@ from __future__ import absolute_import
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import str
+from past.utils import old_div
 import sys,os,time
 import numpy as np
 from osgeo import ogr
@@ -96,7 +99,7 @@ def main(args):
 		os.mkdir(outdir)
 	cut_to=pargs.cut_to
 	cs=pargs.cs
-	ncols_f=TILE_SIZE/cs
+	ncols_f=old_div(TILE_SIZE,cs)
 	ncols=int(ncols_f)
 	nrows=ncols  #tiles are square (for now)
 	if ncols!=ncols_f:

--- a/qc/pointcloud_diff.py
+++ b/qc/pointcloud_diff.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,8 +15,6 @@ from __future__ import division
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import str
-from past.utils import old_div
 import sys,os,time
 import numpy as np
 from osgeo import ogr
@@ -99,7 +96,7 @@ def main(args):
 		os.mkdir(outdir)
 	cut_to=pargs.cut_to
 	cs=pargs.cs
-	ncols_f=old_div(TILE_SIZE,cs)
+	ncols_f=TILE_SIZE/cs
 	ncols=int(ncols_f)
 	nrows=ncols  #tiles are square (for now)
 	if ncols!=ncols_f:

--- a/qc/poly_z_stats.py
+++ b/qc/poly_z_stats.py
@@ -19,7 +19,6 @@ Calculate statistics on the vertical component within polygons.
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
 import sys
 import os
 import time

--- a/qc/poly_z_stats.py
+++ b/qc/poly_z_stats.py
@@ -17,19 +17,20 @@
 Calculate statistics on the vertical component within polygons.
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 import os
 import time
 import numpy as np
 
-import dhmqc_constants as constants
-from thatsDEM import pointcloud
-from thatsDEM import vector_io
-from thatsDEM import array_geometry
-from thatsDEM import grid
-from db import report
-from utils.osutils import ArgumentParser
+from . import dhmqc_constants as constants
+from .thatsDEM import pointcloud
+from .thatsDEM import vector_io
+from .thatsDEM import array_geometry
+from .thatsDEM import grid
+from .db import report
+from .utils.osutils import ArgumentParser
 
 
 #z_min = 1.0
@@ -95,7 +96,7 @@ def usage():
 def main(args):
     try:
         pargs = parser.parse_args(args[1:])
-    except Exception, error_msg:
+    except Exception as error_msg:
         print(str(error_msg))
         return 1
 

--- a/qc/poly_z_stats.py
+++ b/qc/poly_z_stats.py
@@ -19,6 +19,7 @@ Calculate statistics on the vertical component within polygons.
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
 import sys
 import os
 import time

--- a/qc/recreate_local_datasource.py
+++ b/qc/recreate_local_datasource.py
@@ -18,9 +18,10 @@
 
 Creates a spatialite file where qc tests can report to.
 '''
+from __future__ import absolute_import
 
 import os
-from db import report
+from .db import report
 
 here = os.path.dirname(__file__)
 try:

--- a/qc/reproject.py
+++ b/qc/reproject.py
@@ -18,15 +18,17 @@ Coordinate transformation is powered by PDAL behind the scenes. The PDAL executa
 be in the system path, otherwise the script will fail.
 
 '''
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 import os
 import subprocess
 import time
 import json
 
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
-import dhmqc_constants as constants
+from . import dhmqc_constants as constants
 
 PDAL = 'pdal'
 
@@ -106,7 +108,7 @@ def main(args):
     out_file = os.path.join(pargs.out_dir, os.path.basename(pargs.las_file))
 
     if not os.path.exists(pargs.out_dir):
-        print pargs.out_dir
+        print(pargs.out_dir)
         os.makedirs(os.path.abspath(pargs.out_dir))
 
     # create pipeline

--- a/qc/reproject.py
+++ b/qc/reproject.py
@@ -20,6 +20,7 @@ be in the system path, otherwise the script will fail.
 '''
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import str
 import sys
 import os
 import subprocess

--- a/qc/reproject.py
+++ b/qc/reproject.py
@@ -20,7 +20,6 @@ be in the system path, otherwise the script will fail.
 '''
 from __future__ import print_function
 from __future__ import absolute_import
-from builtins import str
 import sys
 import os
 import subprocess

--- a/qc/road_node_outliers.py
+++ b/qc/road_node_outliers.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
+from builtins import str
+from builtins import range
 import sys,os,time
 import math
 import numpy as np

--- a/qc/road_node_outliers.py
+++ b/qc/road_node_outliers.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
-from builtins import str
-from builtins import range
 import sys,os,time
 import math
 import numpy as np

--- a/qc/road_node_outliers.py
+++ b/qc/road_node_outliers.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -20,10 +22,10 @@ import sys,os,time
 import math
 import numpy as np
 from osgeo import ogr
-from thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
-from db import report
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from .thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
+from .db import report
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 #path to geoid
 GEOID_GRID=os.path.join(os.path.dirname(__file__),"..","data","dkgeoid13b_utm32.tif")
 #The class(es) we want to look at...
@@ -60,7 +62,7 @@ def usage():
 def main(args):
     try:
         pargs=parser.parse_args(args[1:])
-    except Exception,e:
+    except Exception as e:
         print(str(e))
         return 1
     kmname=constants.get_tilename(pargs.las_file)
@@ -73,7 +75,7 @@ def main(args):
     reporter=report.ReportLineOutliers(use_local)
     try:
         extent=np.asarray(constants.tilename_to_extent(kmname))
-    except Exception,e:
+    except Exception as e:
         print("Could not get extent from tilename.")
         raise e
     lines=vector_io.get_features(linename,pargs.layername,pargs.layersql,extent)
@@ -125,7 +127,7 @@ def main(args):
             if xy_ref.shape[0]==0:
                 return 2
             if pargs.debug:
-                print "all",xy_ref.shape[0]
+                print("all",xy_ref.shape[0])
             z_interp=pc.idw_filter(pargs.srad,xy=xy_ref,nd_val=-9999)
             dz=(z_interp-z_ref)
             M=np.logical_and(z_interp!=-9999,np.fabs(dz)>=pargs.zlim)
@@ -135,7 +137,7 @@ def main(args):
             xy_ref=xy_ref[M]
             dz=dz[M]
             if pargs.debug:
-                print "bad",xy_ref.shape[0]
+                print("bad",xy_ref.shape[0])
             #find the triangles
             for i in range(dz.shape[0]):
                 wkt="POINT({0} {1} {2})".format(str(xy_ref[i,0]),str(xy_ref[i,1]),str(z_ref[i]))

--- a/qc/roof_ridge_alignment.py
+++ b/qc/roof_ridge_alignment.py
@@ -21,7 +21,11 @@ Houses with parallel roof patches at different heights are problematic - would b
 # work in progress...
 '''
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys
 import os
 import time
@@ -129,7 +133,7 @@ def get_intersections(poly, line):
     for i in range(poly.shape[0] - 1):  # polygon is closed...
         v = poly[i + 1] - poly[i]  # that gives us a,b for that line
         n_v = np.sqrt((v**2).sum())
-        cosv = np.dot(v, a_line) / (n_v * n_line)
+        cosv = old_div(np.dot(v, a_line), (n_v * n_line))
         try:
             a = degrees(acos(cosv))
         except Exception as e:
@@ -150,11 +154,11 @@ def get_intersections(poly, line):
             xy_v = xy - poly[i]
             # check that we actually get something on the line...
             n_xy_v = np.sqrt((xy_v**2).sum())
-            cosv = np.dot(v, xy_v) / (n_v * n_xy_v)
-            if abs(cosv - 1) < 0.01 and n_xy_v / n_v < 1.0:
+            cosv = old_div(np.dot(v, xy_v), (n_v * n_xy_v))
+            if abs(cosv - 1) < 0.01 and old_div(n_xy_v, n_v) < 1.0:
                 center = poly[i] + v * 0.5
                 d = np.sqrt(((center - xy)**2).sum())
-                cosv = np.dot(n2, a_line) / (n_v * n_line)
+                cosv = old_div(np.dot(n2, a_line), (n_v * n_line))
                 try:
                     rot = degrees(acos(cosv)) - 90.0
                 except Exception as e:
@@ -252,12 +256,12 @@ def main(args):
                 z_val = float(np.mean(z_vals))
                 print("Z for intersection is %.2f m" % z_val)
                 if abs(equation[1]) > 1e-3:
-                    a = -equation[0] / equation[1]
-                    b = equation[2] / equation[1]
+                    a = old_div(-equation[0], equation[1])
+                    b = old_div(equation[2], equation[1])
                     line_y = a * line_x + b
                 elif abs(equation[0]) > 1e-3:
-                    a = -equation[1] / equation[0]
-                    b = equation[2] / equation[0]
+                    a = old_div(-equation[1], equation[0])
+                    b = old_div(equation[2], equation[0])
                     line_x = a * line_y + b
                 if DEBUG:
                     plot_intersections(a_poly, intersections, line_x, line_y)

--- a/qc/roof_ridge_alignment.py
+++ b/qc/roof_ridge_alignment.py
@@ -21,11 +21,7 @@ Houses with parallel roof patches at different heights are problematic - would b
 # work in progress...
 '''
 from __future__ import print_function
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys
 import os
 import time
@@ -133,7 +129,7 @@ def get_intersections(poly, line):
     for i in range(poly.shape[0] - 1):  # polygon is closed...
         v = poly[i + 1] - poly[i]  # that gives us a,b for that line
         n_v = np.sqrt((v**2).sum())
-        cosv = old_div(np.dot(v, a_line), (n_v * n_line))
+        cosv = np.dot(v, a_line) / (n_v * n_line)
         try:
             a = degrees(acos(cosv))
         except Exception as e:
@@ -154,11 +150,11 @@ def get_intersections(poly, line):
             xy_v = xy - poly[i]
             # check that we actually get something on the line...
             n_xy_v = np.sqrt((xy_v**2).sum())
-            cosv = old_div(np.dot(v, xy_v), (n_v * n_xy_v))
-            if abs(cosv - 1) < 0.01 and old_div(n_xy_v, n_v) < 1.0:
+            cosv = np.dot(v, xy_v) / (n_v * n_xy_v)
+            if abs(cosv - 1) < 0.01 and n_xy_v / n_v < 1.0:
                 center = poly[i] + v * 0.5
                 d = np.sqrt(((center - xy)**2).sum())
-                cosv = old_div(np.dot(n2, a_line), (n_v * n_line))
+                cosv = np.dot(n2, a_line) / (n_v * n_line)
                 try:
                     rot = degrees(acos(cosv)) - 90.0
                 except Exception as e:
@@ -256,12 +252,12 @@ def main(args):
                 z_val = float(np.mean(z_vals))
                 print("Z for intersection is %.2f m" % z_val)
                 if abs(equation[1]) > 1e-3:
-                    a = old_div(-equation[0], equation[1])
-                    b = old_div(equation[2], equation[1])
+                    a = -equation[0] / equation[1]
+                    b = equation[2] / equation[1]
                     line_y = a * line_x + b
                 elif abs(equation[0]) > 1e-3:
-                    a = old_div(-equation[1], equation[0])
-                    b = old_div(equation[2], equation[0])
+                    a = -equation[1] / equation[0]
+                    b = equation[2] / equation[0]
                     line_x = a * line_y + b
                 if DEBUG:
                     plot_intersections(a_poly, intersections, line_x, line_y)

--- a/qc/roof_ridge_alignment.py
+++ b/qc/roof_ridge_alignment.py
@@ -22,6 +22,8 @@ Houses with parallel roof patches at different heights are problematic - would b
 '''
 from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import sys
 import os
 import time

--- a/qc/roof_ridge_strip.py
+++ b/qc/roof_ridge_strip.py
@@ -23,7 +23,9 @@ work in progress...
 '''
 
 from __future__ import print_function
+from __future__ import division
 
+from past.utils import old_div
 import sys
 import os
 import time
@@ -201,8 +203,8 @@ def main(args):
                     print("Numeric instablity, small normal")
                     break
                 # this should be on the line
-                cm_line = np.asarray(equation[:2]) * (equation[2] / norm_normal)
-                line_dir = np.asarray((-equation[1], equation[0])) / (sqrt(norm_normal))
+                cm_line = np.asarray(equation[:2]) * (old_div(equation[2], norm_normal))
+                line_dir = old_div(np.asarray((-equation[1], equation[0])), (sqrt(norm_normal)))
                 end1 = cm_line + line_dir * LINE_RAD
                 end2 = cm_line - line_dir * LINE_RAD
                 intersections = np.vstack((end1, end2))

--- a/qc/roof_ridge_strip.py
+++ b/qc/roof_ridge_strip.py
@@ -23,9 +23,7 @@ work in progress...
 '''
 
 from __future__ import print_function
-from __future__ import division
 
-from past.utils import old_div
 import sys
 import os
 import time
@@ -203,8 +201,8 @@ def main(args):
                     print("Numeric instablity, small normal")
                     break
                 # this should be on the line
-                cm_line = np.asarray(equation[:2]) * (old_div(equation[2], norm_normal))
-                line_dir = old_div(np.asarray((-equation[1], equation[0])), (sqrt(norm_normal)))
+                cm_line = np.asarray(equation[:2]) * (equation[2] / norm_normal)
+                line_dir = np.asarray((-equation[1], equation[0])) / (sqrt(norm_normal))
                 end1 = cm_line + line_dir * LINE_RAD
                 end2 = cm_line - line_dir * LINE_RAD
                 intersections = np.vstack((end1, end2))

--- a/qc/set_lake_z.py
+++ b/qc/set_lake_z.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
+from builtins import range
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import pointcloud, vector_io, array_geometry,grid

--- a/qc/set_lake_z.py
+++ b/qc/set_lake_z.py
@@ -1,6 +1,10 @@
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import pointcloud, vector_io, array_geometry,grid
@@ -149,8 +153,8 @@ def main(args):
         print(extent_here)
         cs=CS
         geo_ref=[extent_here[0],cs,0,extent_here[3],0,-cs]
-        ncols=int((extent_here[2]-extent_here[0])/cs)
-        nrows=int((extent_here[3]-extent_here[1])/cs)
+        ncols=int(old_div((extent_here[2]-extent_here[0]),cs))
+        nrows=int(old_div((extent_here[3]-extent_here[1]),cs))
         xy_mesh=pointcloud.mesh_as_points((nrows,ncols),geo_ref)
         z_mesh=np.zeros((xy_mesh.shape[0],),dtype=np.float64)
         pc_mesh=pointcloud.Pointcloud(xy_mesh,z_mesh)
@@ -225,7 +229,7 @@ def main(args):
         if pargs.verbose:
             print("Has voids: %d" %has_voids)
         if n_used>0:
-            burn_z=((n_used)*burn_z+(z_dvr90)*n_used_here)/(n_used_here+n_used)
+            burn_z=old_div(((n_used)*burn_z+(z_dvr90)*n_used_here),(n_used_here+n_used))
             n_used=n_used_here+n_used
         else:
             burn_z=z_dvr90
@@ -259,7 +263,7 @@ def main(args):
                 if pargs.verbose:
                     print("Has voids: %d" %has_voids)
                 if n_used>0:
-                    burn_z=((n_used)*burn_z+(z_dvr90)*n_used_here)/(n_used_here+n_used)
+                    burn_z=old_div(((n_used)*burn_z+(z_dvr90)*n_used_here),(n_used_here+n_used))
                     n_used=n_used_here+n_used
                 else:
                     burn_z=z_dvr90

--- a/qc/set_lake_z.py
+++ b/qc/set_lake_z.py
@@ -1,14 +1,16 @@
+from __future__ import print_function
+from __future__ import absolute_import
 
 import sys,os,time
 #import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry,grid
-from db import report
+from .thatsDEM import pointcloud, vector_io, array_geometry,grid
+from .db import report
 from osgeo import ogr
 import numpy as np
 #import pyspatialite.dbapi2 as db
 import psycopg2 as db
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 GEOID_GRID=os.path.join(os.path.dirname(__file__),"..","data","dkgeoid13b_utm32.tif")
 cut_to=[constants.terrain,constants.water]
 CS=0.4 #cellsize for testing point distance
@@ -64,7 +66,7 @@ def set_sql_commands(pargs,wkt):
 def main(args):
     try:
         pargs=parser.parse_args(args[1:])
-    except Exception,e:
+    except Exception as e:
         print(str(e))
         return 1
     if pargs.las_file!="__db__": #hackish, but handy... see above
@@ -72,7 +74,7 @@ def main(args):
         print("Running %s on block: %s, %s" %(progname,kmname,time.asctime()))
         try:
             extent=constants.tilename_to_extent(kmname)
-        except Exception,e:
+        except Exception as e:
             print("Bad tilename:")
             print(str(e))
             return 1
@@ -144,7 +146,7 @@ def main(args):
             pc=pointcloud.fromAny(pargs.las_file).cut_to_class(cut_to)
         lake_extent=lake_geom.GetEnvelope()
         extent_here=[max(lake_extent[0],extent[0]),max(lake_extent[2],extent[1]),min(lake_extent[1],extent[2]),min(lake_extent[3],extent[3])]
-        print extent_here
+        print(extent_here)
         cs=CS
         geo_ref=[extent_here[0],cs,0,extent_here[3],0,-cs]
         ncols=int((extent_here[2]-extent_here[0])/cs)

--- a/qc/set_lake_z.py
+++ b/qc/set_lake_z.py
@@ -1,10 +1,6 @@
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import pointcloud, vector_io, array_geometry,grid
@@ -153,8 +149,8 @@ def main(args):
         print(extent_here)
         cs=CS
         geo_ref=[extent_here[0],cs,0,extent_here[3],0,-cs]
-        ncols=int(old_div((extent_here[2]-extent_here[0]),cs))
-        nrows=int(old_div((extent_here[3]-extent_here[1]),cs))
+        ncols=int((extent_here[2]-extent_here[0])/cs)
+        nrows=int((extent_here[3]-extent_here[1])/cs)
         xy_mesh=pointcloud.mesh_as_points((nrows,ncols),geo_ref)
         z_mesh=np.zeros((xy_mesh.shape[0],),dtype=np.float64)
         pc_mesh=pointcloud.Pointcloud(xy_mesh,z_mesh)
@@ -229,7 +225,7 @@ def main(args):
         if pargs.verbose:
             print("Has voids: %d" %has_voids)
         if n_used>0:
-            burn_z=old_div(((n_used)*burn_z+(z_dvr90)*n_used_here),(n_used_here+n_used))
+            burn_z=((n_used)*burn_z+(z_dvr90)*n_used_here)/(n_used_here+n_used)
             n_used=n_used_here+n_used
         else:
             burn_z=z_dvr90
@@ -263,7 +259,7 @@ def main(args):
                 if pargs.verbose:
                     print("Has voids: %d" %has_voids)
                 if n_used>0:
-                    burn_z=old_div(((n_used)*burn_z+(z_dvr90)*n_used_here),(n_used_here+n_used))
+                    burn_z=((n_used)*burn_z+(z_dvr90)*n_used_here)/(n_used_here+n_used)
                     n_used=n_used_here+n_used
                 else:
                     burn_z=z_dvr90

--- a/qc/spike_check.py
+++ b/qc/spike_check.py
@@ -18,6 +18,7 @@ Spike check: Check for steep somewhat isolated triangles.
 '''
 from __future__ import print_function
 
+from builtins import range
 import sys
 import os
 import time

--- a/qc/spike_check.py
+++ b/qc/spike_check.py
@@ -18,7 +18,6 @@ Spike check: Check for steep somewhat isolated triangles.
 '''
 from __future__ import print_function
 
-from builtins import range
 import sys
 import os
 import time

--- a/qc/steep_triangles.py
+++ b/qc/steep_triangles.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -19,12 +21,12 @@
 ######################################################################################
 import sys,os,time
 #import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry
-from db import report
+from .thatsDEM import pointcloud, vector_io, array_geometry
+from .db import report
 from math import tan,radians
 import numpy as np
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 
 cut_to=constants.water
 xy_max=2 #dont care about triangles larger than this
@@ -56,7 +58,7 @@ def usage():
 def main(args):
 	try:
 		pargs=parser.parse_args(args[1:])
-	except Exception,e:
+	except Exception as e:
 		print(str(e))
 		return 1
 	lasname=pargs.las_file

--- a/qc/steep_triangles.py
+++ b/qc/steep_triangles.py
@@ -19,6 +19,8 @@ from __future__ import absolute_import
 ##  Test for water that aint flat... or just find steep triangles...
 ## pretty much like road_delta_check
 ######################################################################################
+from builtins import str
+from builtins import range
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import pointcloud, vector_io, array_geometry
@@ -86,7 +88,7 @@ def main(args):
 		return 0
 	centers=pc.triangulation.get_triangle_centers()[M] #only the centers of the interesting triangles
 	slopes=np.degrees(np.arctan(np.sqrt(geom[:,0])))
-	for i in xrange(centers.shape[0]):
+	for i in range(centers.shape[0]):
 		center=centers[i]
 		slope=slopes[i]
 		bbxy=geom[i][1]

--- a/qc/steep_triangles.py
+++ b/qc/steep_triangles.py
@@ -19,8 +19,6 @@ from __future__ import absolute_import
 ##  Test for water that aint flat... or just find steep triangles...
 ## pretty much like road_delta_check
 ######################################################################################
-from builtins import str
-from builtins import range
 import sys,os,time
 #import some relevant modules...
 from .thatsDEM import pointcloud, vector_io, array_geometry
@@ -88,7 +86,7 @@ def main(args):
 		return 0
 	centers=pc.triangulation.get_triangle_centers()[M] #only the centers of the interesting triangles
 	slopes=np.degrees(np.arctan(np.sqrt(geom[:,0])))
-	for i in range(centers.shape[0]):
+	for i in xrange(centers.shape[0]):
 		center=centers[i]
 		slope=slopes[i]
 		bbxy=geom[i][1]

--- a/qc/template.py
+++ b/qc/template.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 ##  TEMPLATE FOR A TEST TO BE WRAPPED
 ##  FILL IN AND DELETE BELOW...
 ######################################################################################
-from builtins import str
 import sys
 import os
 import time

--- a/qc/template.py
+++ b/qc/template.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -24,15 +26,15 @@ import time
 import numpy as np
 
 # Import some relevant modules...
-from thatsDEM import pointcloud, vector_io, array_geometry
-from db import report
-import dhmqc_constants as constants
+from .thatsDEM import pointcloud, vector_io, array_geometry
+from .db import report
+from . import dhmqc_constants as constants
 
 # If you want this script to be included in the test-suite use this subclass.
 # Otherwise argparse.ArgumentParser will be the best choice :-)
 # utils.osutils.Argumentparser is a simple subclass of argparse.ArgumentParser
 # which raises an exception instead of using sys.exit if supplied with bad arguments...
-from utils.osutils import ArgumentParser
+from .utils.osutils import ArgumentParser
 
 z_min  =  1.0
 cut_to =  constants.terrain

--- a/qc/template.py
+++ b/qc/template.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 ##  TEMPLATE FOR A TEST TO BE WRAPPED
 ##  FILL IN AND DELETE BELOW...
 ######################################################################################
+from builtins import str
 import sys
 import os
 import time

--- a/qc/thatsDEM/array_factory.py
+++ b/qc/thatsDEM/array_factory.py
@@ -1,3 +1,4 @@
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -19,6 +20,7 @@
 # np.int32   <->  int  (on some platforms)
 # np.bool     <-> char
 #####################
+from past.utils import old_div
 import numpy as np
 
 # These functions should not copy data when input is ok....
@@ -30,7 +32,7 @@ def point_factory(xy):
         n = xy.shape[0]
         if n % 2 != 0:
             raise TypeError("Input must have size n*2")
-        xy = xy.reshape((int(n / 2), 2))
+        xy = xy.reshape((int(old_div(n, 2)), 2))
     return np.require(xy, dtype=np.float64, requirements=[
                       'A', 'O', 'C'])  # aligned, own_data, c-contiguous
 

--- a/qc/thatsDEM/array_factory.py
+++ b/qc/thatsDEM/array_factory.py
@@ -1,4 +1,3 @@
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -20,7 +19,6 @@ from __future__ import division
 # np.int32   <->  int  (on some platforms)
 # np.bool     <-> char
 #####################
-from past.utils import old_div
 import numpy as np
 
 # These functions should not copy data when input is ok....
@@ -32,7 +30,7 @@ def point_factory(xy):
         n = xy.shape[0]
         if n % 2 != 0:
             raise TypeError("Input must have size n*2")
-        xy = xy.reshape((int(old_div(n, 2)), 2))
+        xy = xy.reshape((int(n / 2), 2))
     return np.require(xy, dtype=np.float64, requirements=[
                       'A', 'O', 'C'])  # aligned, own_data, c-contiguous
 

--- a/qc/thatsDEM/array_geometry.py
+++ b/qc/thatsDEM/array_geometry.py
@@ -12,6 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import range
 import sys
 import os
 import ctypes
@@ -178,7 +179,7 @@ def ogrpoints2array(ogr_geoms):
     Slow interface.
     """
     out = np.empty((len(ogr_geoms), 3), dtype=np.float64)
-    for i in xrange(len(ogr_geoms)):
+    for i in range(len(ogr_geoms)):
         out[i, :] = ogr_geoms[i].GetPoint()
     return out
 

--- a/qc/thatsDEM/array_geometry.py
+++ b/qc/thatsDEM/array_geometry.py
@@ -1,3 +1,4 @@
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -12,6 +13,8 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import range
+from past.utils import old_div
 import sys
 import os
 import ctypes
@@ -178,7 +181,7 @@ def ogrpoints2array(ogr_geoms):
     Slow interface.
     """
     out = np.empty((len(ogr_geoms), 3), dtype=np.float64)
-    for i in xrange(len(ogr_geoms)):
+    for i in range(len(ogr_geoms)):
         out[i, :] = ogr_geoms[i].GetPoint()
     return out
 
@@ -365,7 +368,7 @@ def linestring_displacements(xy):
     """
     dxy = xy[1:] - xy[:-1]
     ndxy = np.sqrt((dxy**2).sum(axis=1)).reshape((dxy.shape[0], 1))  # should return a 1d array...
-    hat = np.column_stack((-dxy[:, 1], dxy[:, 0])) / ndxy  # dxy should be 2d
+    hat = old_div(np.column_stack((-dxy[:, 1], dxy[:, 0])), ndxy)  # dxy should be 2d
     normals = hat[0]
     # calculate the 'inner normals' - if any...
     if hat.shape[0] > 1:
@@ -373,7 +376,7 @@ def linestring_displacements(xy):
         # dot of inner normal with corresponding hat should be = 1
         #<(v1+v2),v1>=1+<v1,v2>=<(v1+v2),v2>
         # assert ( not (dots==-1).any() ) - no 180 deg. turns!
-        alpha = 1 / (1 + dots)
+        alpha = old_div(1, (1 + dots))
         # should be 2d - even with one row - else use np.atleast_2d
         inner_normals = (hat[:-1] + hat[1:]) * alpha
         normals = np.vstack((normals, inner_normals))

--- a/qc/thatsDEM/array_geometry.py
+++ b/qc/thatsDEM/array_geometry.py
@@ -1,4 +1,3 @@
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -13,8 +12,6 @@ from __future__ import division
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import range
-from past.utils import old_div
 import sys
 import os
 import ctypes
@@ -181,7 +178,7 @@ def ogrpoints2array(ogr_geoms):
     Slow interface.
     """
     out = np.empty((len(ogr_geoms), 3), dtype=np.float64)
-    for i in range(len(ogr_geoms)):
+    for i in xrange(len(ogr_geoms)):
         out[i, :] = ogr_geoms[i].GetPoint()
     return out
 
@@ -368,7 +365,7 @@ def linestring_displacements(xy):
     """
     dxy = xy[1:] - xy[:-1]
     ndxy = np.sqrt((dxy**2).sum(axis=1)).reshape((dxy.shape[0], 1))  # should return a 1d array...
-    hat = old_div(np.column_stack((-dxy[:, 1], dxy[:, 0])), ndxy)  # dxy should be 2d
+    hat = np.column_stack((-dxy[:, 1], dxy[:, 0])) / ndxy  # dxy should be 2d
     normals = hat[0]
     # calculate the 'inner normals' - if any...
     if hat.shape[0] > 1:
@@ -376,7 +373,7 @@ def linestring_displacements(xy):
         # dot of inner normal with corresponding hat should be = 1
         #<(v1+v2),v1>=1+<v1,v2>=<(v1+v2),v2>
         # assert ( not (dots==-1).any() ) - no 180 deg. turns!
-        alpha = old_div(1, (1 + dots))
+        alpha = 1 / (1 + dots)
         # should be 2d - even with one row - else use np.atleast_2d
         inner_normals = (hat[:-1] + hat[1:]) * alpha
         normals = np.vstack((normals, inner_normals))

--- a/qc/thatsDEM/grid.py
+++ b/qc/thatsDEM/grid.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -16,6 +17,9 @@ from __future__ import print_function
 ######################################
 # Grid class below  - just a numpy array and some metadata + some usefull methods
 ####################################
+from builtins import range
+from builtins import object
+from past.utils import old_div
 import numpy as np
 import os
 from osgeo import gdal
@@ -183,7 +187,7 @@ def make_grid(xy, q, ncols, nrows, georef, nd_val=-9999, method=np.mean, dtype=n
         2d numpy array of shape (nrows,ncols).
     """
     out = np.ones((nrows, ncols), dtype=dtype) * nd_val
-    arr_coords = ((xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int32)
+    arr_coords = (old_div((xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int32)
     M = np.logical_and(arr_coords[:, 0] >= 0, arr_coords[:, 0] < ncols)
     M &= np.logical_and(arr_coords[:, 1] >= 0, arr_coords[:, 1] < nrows)
     arr_coords = arr_coords[M]
@@ -199,7 +203,7 @@ def make_grid(xy, q, ncols, nrows, georef, nd_val=-9999, method=np.mean, dtype=n
     i0 = 0
     row = arr_coords[0, 1]
     col = arr_coords[0, 0]
-    for i in xrange(arr_coords.shape[0]):
+    for i in range(arr_coords.shape[0]):
         b = arr_coords[i, 1] * ncols + arr_coords[i, 0]
         if (b > box_index):
             # set the current cell
@@ -224,7 +228,7 @@ def grid_most_frequent_value(xy, q, ncols, nrows, georef, v1=None, v2=None, nd_v
     # void grid_most_frequent_value(int *sorted_indices, int *values, int
     # *out, int vmin,int vmax,int nd_val, int n)
     out = np.ones((nrows, ncols), dtype=np.int32) * nd_val
-    arr_coords = ((xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int32)
+    arr_coords = (old_div((xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int32)
     M = np.logical_and(arr_coords[:, 0] >= 0, arr_coords[:, 0] < ncols)
     M &= np.logical_and(arr_coords[:, 1] >= 0, arr_coords[:, 1] < nrows)
     arr_coords = arr_coords[M]
@@ -247,7 +251,7 @@ def grid_most_frequent_value(xy, q, ncols, nrows, georef, v1=None, v2=None, nd_v
 def user2array(georef, xy):
     # Return array coordinates (as int32 here) for input points in 'real'
     # coordinates. georef is a GDAL style georeference.
-    return ((xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int32)
+    return (old_div((xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int32)
 
 
 def grid_extent(geo_ref, shape):
@@ -453,15 +457,15 @@ class Grid(object):
         ang = np.radians(360 - azimuth + 90)
         h_rad = np.radians(height)
         light = np.array((np.cos(ang) * np.cos(h_rad), np.sin(ang) * np.cos(h_rad), np.sin(h_rad)))
-        light = light / (np.sqrt(light.dot(light)))  # normalise
+        light = old_div(light, (np.sqrt(light.dot(light))))  # normalise
         if method == 0:
             kernel = H_KERNEL
             k_factor = 8
         else:
             kernel = ZT_KERNEL
             k_factor = 2
-        scale_x = z_factor / (self.geo_ref[1] * k_factor)  # scale down
-        scale_y = z_factor / (self.geo_ref[5] * k_factor)
+        scale_x = old_div(z_factor, (self.geo_ref[1] * k_factor))  # scale down
+        scale_y = old_div(z_factor, (self.geo_ref[5] * k_factor))
         dx = image.filters.correlate(self.grid, kernel) * scale_x
         # taking care of revered axis since cy<0
         dy = image.filters.correlate(self.grid, kernel.T) * scale_y
@@ -470,7 +474,7 @@ class Grid(object):
         # calculate the dot product and normalise - should be in range -1 to 1 -
         # less than zero means black, which here should translate to the value 1
         # as a ubyte.
-        X = (-dx * light[0] - dy * light[1] + light[2]) / X
+        X = old_div((-dx * light[0] - dy * light[1] + light[2]), X)
         print("{} {}".format(X.min(), X.max()))
         X[X < 0] = 0  # dark pixels should have value 1
         X = X * 254 + 1

--- a/qc/thatsDEM/grid.py
+++ b/qc/thatsDEM/grid.py
@@ -16,6 +16,8 @@ from __future__ import print_function
 ######################################
 # Grid class below  - just a numpy array and some metadata + some usefull methods
 ####################################
+from builtins import range
+from builtins import object
 import numpy as np
 import os
 from osgeo import gdal
@@ -199,7 +201,7 @@ def make_grid(xy, q, ncols, nrows, georef, nd_val=-9999, method=np.mean, dtype=n
     i0 = 0
     row = arr_coords[0, 1]
     col = arr_coords[0, 0]
-    for i in xrange(arr_coords.shape[0]):
+    for i in range(arr_coords.shape[0]):
         b = arr_coords[i, 1] * ncols + arr_coords[i, 0]
         if (b > box_index):
             # set the current cell

--- a/qc/thatsDEM/grid.py
+++ b/qc/thatsDEM/grid.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any

--- a/qc/thatsDEM/pointcloud.py
+++ b/qc/thatsDEM/pointcloud.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -1231,9 +1232,9 @@ def unit_test(path):
     crop = extent + (rx, ry, -rx, -ry)
     pc1 = pc1.cut_to_box(*crop)
     print("Reading filtered")
-    print(crop, type(crop))
+    print((crop, type(crop)))
     (a1, a2, a3, a4) = crop
-    print(a1, a2, a3, a4)
+    print((a1, a2, a3, a4))
     pc2 = fromLAS(path, xy_box=crop)
     assert(pc1.get_size() == pc2.get_size())
     assert((pc1.get_classes() == pc2.get_classes()).all())

--- a/qc/thatsDEM/pointcloud.py
+++ b/qc/thatsDEM/pointcloud.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 ##
 ############################
 
+from builtins import range
+from builtins import object
 import sys
 import os
 import numpy as np
@@ -905,7 +907,7 @@ class Pointcloud(object):
             has_id = True
         f.write("\n")
         n = self.get_size()
-        for i in xrange(n):
+        for i in range(n):
             f.write("{0:.2f},{1:.2f},{2:.2f}".format(self.xy[i, 0], self.xy[i, 1], self.z[i]))
             if has_c:
                 f.write(",{0:d}".format(self.c[i]))

--- a/qc/thatsDEM/pointcloud.py
+++ b/qc/thatsDEM/pointcloud.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -19,9 +18,6 @@ from __future__ import division
 ##
 ############################
 
-from builtins import range
-from builtins import object
-from past.utils import old_div
 import sys
 import os
 import numpy as np
@@ -167,7 +163,7 @@ def fromPatch(path, **kwargs):
     xyzcpc = np.fromfile(path, dtype=np.float64)
     n = xyzcpc.size
     assert(n % 6 == 0)
-    n_recs = int(old_div(n, 6))
+    n_recs = int(n / 6)
     xyzcpc = xyzcpc.reshape((n_recs, 6))
     # use new class as class
     return Pointcloud(xyzcpc[:, :2], xyzcpc[:, 2], c=xyzcpc[
@@ -188,7 +184,7 @@ def fromBinary(path, **kwargs):
     xyzcp = np.fromfile(path, dtype=np.float64)
     n = xyzcp.size
     assert(n % 5 == 0)
-    n_recs = int(old_div(n, 5))
+    n_recs = int(n / 5)
     xyzcp = xyzcp.reshape((n_recs, 5))
     return Pointcloud(xyzcp[:, :2], xyzcp[:, 2], c=xyzcp[:, 3].astype(
         np.int32), pid=xyzcp[:, 4].astype(np.int32))
@@ -503,7 +499,7 @@ class Pointcloud(object):
         Returns:
             A numpy 1d boolean mask.
         """
-        ac = (old_div((self.xy - (georef[0], georef[3])), (georef[1], georef[5]))).astype(np.int32)
+        ac = ((self.xy - (georef[0], georef[3])) / (georef[1], georef[5])).astype(np.int32)
         N = np.logical_and(ac >= (0, 0), ac < (M.shape[1], M.shape[0])).all(axis=1)
         ac = ac[N]
         MM = np.zeros((self.xy.shape[0],), dtype=np.bool)
@@ -685,11 +681,11 @@ class Pointcloud(object):
         if nrows is None and cy is None:
             raise ValueError("Unable to compute grid extent from input data")
         if ncols is None:
-            ncols = int(ceil(old_div((x2 - x1), cx)))
+            ncols = int(ceil((x2 - x1) / cx))
         else:
             cx = (x2 - x1) / float(ncols)
         if nrows is None:
-            nrows = int(ceil(old_div((y2 - y1), cy)))
+            nrows = int(ceil((y2 - y1) / cy))
         else:
             cy = (y2 - y1) / float(nrows)
         # geo ref gdal style...
@@ -707,8 +703,8 @@ class Pointcloud(object):
                 self.z, ncols, nrows, x1, cx, y2, cy, nd_val, return_triangles=True)
             return grid.Grid(g, geo_ref, nd_val), grid.Grid(t, geo_ref, nd_val)
         elif method == "density":  # density grid
-            arr_coords = (old_div((self.xy - (geo_ref[0], geo_ref[3])),
-                          (geo_ref[1], geo_ref[5]))).astype(np.int32)
+            arr_coords = ((self.xy - (geo_ref[0], geo_ref[3])) /
+                          (geo_ref[1], geo_ref[5])).astype(np.int32)
             M = np.logical_and(arr_coords[:, 0] >= 0, arr_coords[:, 0] < ncols)
             M &= np.logical_and(arr_coords[:, 1] >= 0, arr_coords[:, 1] < nrows)
             arr_coords = arr_coords[M]
@@ -909,7 +905,7 @@ class Pointcloud(object):
             has_id = True
         f.write("\n")
         n = self.get_size()
-        for i in range(n):
+        for i in xrange(n):
             f.write("{0:.2f},{1:.2f},{2:.2f}".format(self.xy[i, 0], self.xy[i, 1], self.z[i]))
             if has_c:
                 f.write(",{0:d}".format(self.c[i]))
@@ -960,12 +956,12 @@ class Pointcloud(object):
         self.clear_derived_attrs()
         if shape is None:
             x1, y1, x2, y2 = self.get_bounds()
-            ncols = int(old_div((x2 - x1), cs)) + 1
-            nrows = int(old_div((y2 - y1), cs)) + 1
+            ncols = int((x2 - x1) / cs) + 1
+            nrows = int((y2 - y1) / cs) + 1
         else:
             x1, y2 = xy_ul
             nrows, ncols = shape
-        arr_coords = (old_div((self.xy - (x1, y2)), (cs, -cs))).astype(np.int32)
+        arr_coords = ((self.xy - (x1, y2)) / (cs, -cs)).astype(np.int32)
         # do we cover the whole area?
         mx, my = arr_coords.min(axis=0)
         Mx, My = arr_coords.max(axis=0)

--- a/qc/thatsDEM/triangle.py
+++ b/qc/thatsDEM/triangle.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2018, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -14,6 +15,8 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from past.utils import old_div
+from builtins import object
 import sys
 import os
 import ctypes
@@ -363,14 +366,14 @@ def unit_test(n1=1000, n2=1000):
     T = tri.find_triangles(xy)
     t2 = time.clock()
     t3 = t2 - t1
-    print("Finding %d simplices: %.4f s, pr. 1e6: %.4f s" % (n2, t3, t3 / n2 * 1e6))
+    print("Finding %d simplices: %.4f s, pr. 1e6: %.4f s" % (n2, t3, old_div(t3, n2 * 1e6)))
     assert T.min() >= 0
     assert T.max() < tri.ntrig
     t1 = time.clock()
     zi = tri.interpolate(z, points)
     t2 = time.clock()
     t3 = t2 - t1
-    print("Interpolation test of vertices:  %.4f s, pr. 1e6: %.4f s" % (t3, t3 / n1 * 1e6))
+    print("Interpolation test of vertices:  %.4f s, pr. 1e6: %.4f s" % (t3, old_div(t3, n1 * 1e6)))
     D = np.fabs(z - zi)
     print("Diff: %.15g, %.15g, %.15g" % (D.max(), D.min(), D.mean()))
     assert(D.max() < 1e-4)

--- a/qc/thatsDEM/triangle.py
+++ b/qc/thatsDEM/triangle.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import object
 import sys
 import os
 import ctypes

--- a/qc/thatsDEM/triangle.py
+++ b/qc/thatsDEM/triangle.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2018, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -15,8 +14,6 @@ from __future__ import division
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from past.utils import old_div
-from builtins import object
 import sys
 import os
 import ctypes
@@ -366,14 +363,14 @@ def unit_test(n1=1000, n2=1000):
     T = tri.find_triangles(xy)
     t2 = time.clock()
     t3 = t2 - t1
-    print("Finding %d simplices: %.4f s, pr. 1e6: %.4f s" % (n2, t3, old_div(t3, n2 * 1e6)))
+    print("Finding %d simplices: %.4f s, pr. 1e6: %.4f s" % (n2, t3, t3 / n2 * 1e6))
     assert T.min() >= 0
     assert T.max() < tri.ntrig
     t1 = time.clock()
     zi = tri.interpolate(z, points)
     t2 = time.clock()
     t3 = t2 - t1
-    print("Interpolation test of vertices:  %.4f s, pr. 1e6: %.4f s" % (t3, old_div(t3, n1 * 1e6)))
+    print("Interpolation test of vertices:  %.4f s, pr. 1e6: %.4f s" % (t3, t3 / n1 * 1e6))
     D = np.fabs(z - zi)
     print("Diff: %.15g, %.15g, %.15g" % (D.max(), D.min(), D.mean()))
     assert(D.max() < 1e-4)

--- a/qc/thatsDEM/triangle.py
+++ b/qc/thatsDEM/triangle.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2018, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 # Stuff to read / burn vector layers
 #########################
 
-from builtins import str
-from builtins import range
 from osgeo import ogr, gdal
 import numpy as np
 import time

--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 # Stuff to read / burn vector layers
 #########################
 
+from builtins import str
+from builtins import range
 from osgeo import ogr, gdal
 import numpy as np
 import time

--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 #
 # Permission to use, copy, modify, and/or distribute this software for any

--- a/qc/time_stats.py
+++ b/qc/time_stats.py
@@ -20,6 +20,7 @@ Create a raster grid of gps time from a pointcloud.
 '''
 
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -29,9 +30,9 @@ from datetime import datetime, timedelta
 import numpy as np
 import laspy
 
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser
-from db import report
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser
+from .db import report
 
 PROGNAME = os.path.basename(__file__).replace(".pyc", ".py")
 
@@ -128,7 +129,7 @@ def main(args):
     '''
     try:
         pargs = parser.parse_args(args[1:])
-    except TypeError, error_msg:
+    except TypeError as error_msg:
         print(str(error_msg))
         return 1
 

--- a/qc/time_stats.py
+++ b/qc/time_stats.py
@@ -22,6 +22,7 @@ Create a raster grid of gps time from a pointcloud.
 from __future__ import print_function
 from __future__ import absolute_import
 
+from builtins import str
 import os
 import sys
 import time

--- a/qc/time_stats.py
+++ b/qc/time_stats.py
@@ -22,7 +22,6 @@ Create a raster grid of gps time from a pointcloud.
 from __future__ import print_function
 from __future__ import absolute_import
 
-from builtins import str
 import os
 import sys
 import time

--- a/qc/utils/npy2tif.py
+++ b/qc/utils/npy2tif.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -22,8 +23,8 @@ def WriteRaster(fname,A,geo,dtype=gdal.GDT_Float32,nd_value=None,colortable=None
 	if os.path.exists(fname):
 		try:
 			driver.Delete(fname)
-		except Exception, msg:
-			print msg
+		except Exception as msg:
+			print(msg)
 		else:
 			print("Overwriting %s..." %fname)
 	else:

--- a/qc/utils/osutils.py
+++ b/qc/utils/osutils.py
@@ -18,7 +18,6 @@
 ## A class to redirect stdout and stderr and various other utils...
 ###########################
 
-from builtins import object
 import sys
 import os
 import subprocess

--- a/qc/utils/osutils.py
+++ b/qc/utils/osutils.py
@@ -18,6 +18,7 @@
 ## A class to redirect stdout and stderr and various other utils...
 ###########################
 
+from builtins import object
 import sys
 import os
 import subprocess

--- a/qc/utils/stats.py
+++ b/qc/utils/stats.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/utils/wmsfetch.py
+++ b/qc/utils/wmsfetch.py
@@ -25,6 +25,7 @@ Example:
           Image size: (500, 500)
 
 """
+from __future__ import print_function
 import os
 import time
 import argparse

--- a/qc/utils/wmsfetch.py
+++ b/qc/utils/wmsfetch.py
@@ -26,8 +26,6 @@ Example:
 
 """
 from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 import os
 import time

--- a/qc/utils/wmsfetch.py
+++ b/qc/utils/wmsfetch.py
@@ -26,11 +26,6 @@ Example:
 
 """
 from __future__ import print_function
-from __future__ import division
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from past.utils import old_div
 import os
 import time
 import argparse
@@ -40,7 +35,7 @@ from osgeo import gdal, osr
 import owslib
 from owslib.wms import WebMapService
 
-from urllib.parse import urlencode
+from urllib import urlencode
 '''
 from owslib.util import openURL
 from owslib.wms import ContentMetadata
@@ -186,8 +181,8 @@ def download_image(tilename, url, layer, outputfile=None, px_size=0.1, timeout=5
 
     bb = (E, N, E+1000, N+1000)
 
-    size_x = int(old_div((bb[2]-bb[0]), px_size))
-    size_y = int(old_div((bb[3]-bb[1]), px_size))
+    size_x = int((bb[2]-bb[0]) / px_size)
+    size_y = int((bb[3]-bb[1]) / px_size)
 
     if verbose:
         print('Downloading %s. It might take a while...' % outputfile)

--- a/qc/utils/wmsfetch.py
+++ b/qc/utils/wmsfetch.py
@@ -26,6 +26,11 @@ Example:
 
 """
 from __future__ import print_function
+from __future__ import division
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.utils import old_div
 import os
 import time
 import argparse
@@ -35,7 +40,7 @@ from osgeo import gdal, osr
 import owslib
 from owslib.wms import WebMapService
 
-from urllib import urlencode
+from urllib.parse import urlencode
 '''
 from owslib.util import openURL
 from owslib.wms import ContentMetadata
@@ -181,8 +186,8 @@ def download_image(tilename, url, layer, outputfile=None, px_size=0.1, timeout=5
 
     bb = (E, N, E+1000, N+1000)
 
-    size_x = int((bb[2]-bb[0]) / px_size)
-    size_y = int((bb[3]-bb[1]) / px_size)
+    size_x = int(old_div((bb[2]-bb[0]), px_size))
+    size_y = int(old_div((bb[3]-bb[1]), px_size))
 
     if verbose:
         print('Downloading %s. It might take a while...' % outputfile)

--- a/qc/utils/wmsfetch.py
+++ b/qc/utils/wmsfetch.py
@@ -26,6 +26,9 @@ Example:
 
 """
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
 import os
 import time
 import argparse
@@ -35,7 +38,7 @@ from osgeo import gdal, osr
 import owslib
 from owslib.wms import WebMapService
 
-from urllib import urlencode
+from urllib.parse import urlencode
 '''
 from owslib.util import openURL
 from owslib.wms import ContentMetadata

--- a/qc/wobbly_water.py
+++ b/qc/wobbly_water.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -18,6 +19,9 @@ from __future__ import print_function
 ## Test for water that aint flat (by using mean filter)
 ##
 ######################################################################################
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 #import some relevant modules...
 from osgeo import gdal,ogr
@@ -61,7 +65,7 @@ def polygonise_points(pc,cs,cell_count_lim=1):
 	ncols=int(float((x2-x1))/cs)+1
 	nrows=int(float((y2-y1))/cs)+1
 	georef=[x1,cs,0,y2,0,-cs]
-	arr_coords=((pc.xy-(georef[0],georef[3]))/(georef[1],georef[5])).astype(np.int32)
+	arr_coords=(old_div((pc.xy-(georef[0],georef[3])),(georef[1],georef[5]))).astype(np.int32)
 	M=np.logical_and(arr_coords[:,0]>=0, arr_coords[:,0]<ncols)
 	M&=np.logical_and(arr_coords[:,1]>=0,arr_coords[:,1]<nrows)
 	arr_coords=arr_coords[M]
@@ -122,7 +126,7 @@ def main(args):
 		diff=diff[M]
 		ds,lyr=polygonise_points(pc,2*pargs.frad,1)
 		nf=lyr.GetFeatureCount()
-		for i in xrange(nf):
+		for i in range(nf):
 			fet=lyr.GetNextFeature()
 			geom=fet.GetGeometryRef()
 			arr_geom=array_geometry.ogrpoly2array(geom,flatten=True)

--- a/qc/wobbly_water.py
+++ b/qc/wobbly_water.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 ## Test for water that aint flat (by using mean filter)
 ##
 ######################################################################################
+from builtins import str
+from builtins import range
 import sys,os,time
 #import some relevant modules...
 from osgeo import gdal,ogr
@@ -122,7 +124,7 @@ def main(args):
 		diff=diff[M]
 		ds,lyr=polygonise_points(pc,2*pargs.frad,1)
 		nf=lyr.GetFeatureCount()
-		for i in xrange(nf):
+		for i in range(nf):
 			fet=lyr.GetNextFeature()
 			geom=fet.GetGeometryRef()
 			arr_geom=array_geometry.ogrpoly2array(geom,flatten=True)

--- a/qc/wobbly_water.py
+++ b/qc/wobbly_water.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -19,9 +18,6 @@ from __future__ import division
 ## Test for water that aint flat (by using mean filter)
 ##
 ######################################################################################
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 #import some relevant modules...
 from osgeo import gdal,ogr
@@ -65,7 +61,7 @@ def polygonise_points(pc,cs,cell_count_lim=1):
 	ncols=int(float((x2-x1))/cs)+1
 	nrows=int(float((y2-y1))/cs)+1
 	georef=[x1,cs,0,y2,0,-cs]
-	arr_coords=(old_div((pc.xy-(georef[0],georef[3])),(georef[1],georef[5]))).astype(np.int32)
+	arr_coords=((pc.xy-(georef[0],georef[3]))/(georef[1],georef[5])).astype(np.int32)
 	M=np.logical_and(arr_coords[:,0]>=0, arr_coords[:,0]<ncols)
 	M&=np.logical_and(arr_coords[:,1]>=0,arr_coords[:,1]<nrows)
 	arr_coords=arr_coords[M]
@@ -126,7 +122,7 @@ def main(args):
 		diff=diff[M]
 		ds,lyr=polygonise_points(pc,2*pargs.frad,1)
 		nf=lyr.GetFeatureCount()
-		for i in range(nf):
+		for i in xrange(nf):
 			fet=lyr.GetNextFeature()
 			geom=fet.GetGeometryRef()
 			arr_geom=array_geometry.ogrpoly2array(geom,flatten=True)

--- a/qc/wobbly_water.py
+++ b/qc/wobbly_water.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/xy_accuracy_buildings.py
+++ b/qc/xy_accuracy_buildings.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -20,6 +21,9 @@ from __future__ import print_function
 ## work in progress...
 ###########################
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report
@@ -75,7 +79,7 @@ def norm(x):
 def residuals(p1,p2,xy):
 	N=(p2-p1)
 	n=np.sqrt(N.dot(N))
-	N=N/n
+	N=old_div(N,n)
 	xy_t=xy-p1
 	p=np.dot(xy_t,N)
 	P=np.empty_like(xy)
@@ -100,10 +104,10 @@ def find_line(p1,p2,pts): #linear regression, brute force or whatever...
 		f=found
 		xy=np.row_stack((p1,p2))
 		if abs(f[0])>abs(f[1]):
-			x=(f[2]-xy[:,1]*f[1])/f[0]
+			x=old_div((f[2]-xy[:,1]*f[1]),f[0])
 			xy2=np.column_stack((x,xy[:,1]))
 		else:
-			y=(f[2]-xy[:,0]*f[0])/f[1]
+			y=old_div((f[2]-xy[:,0]*f[0]),f[1])
 			xy2=np.column_stack((xy[:,0],y))
 		plot_points2(pts,xy2,xy)
 	rot=found[3]-angle
@@ -172,7 +176,7 @@ def check_distribution(p1,p2,xy):
 	f=(M.sum()/float(M.size))
 	#print("Fraction of points 'close' to line %.3f" %f)
 	h,bins=np.histogram(p,n_bins)
-	h=h.astype(np.float64)/p.size
+	h=old_div(h.astype(np.float64),p.size)
 	if (h<0.05).sum()>3:
 		print("Uneven distribution!")
 		return False,None

--- a/qc/xy_accuracy_buildings.py
+++ b/qc/xy_accuracy_buildings.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -21,9 +20,6 @@ from __future__ import division
 ## work in progress...
 ###########################
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report
@@ -79,7 +75,7 @@ def norm(x):
 def residuals(p1,p2,xy):
 	N=(p2-p1)
 	n=np.sqrt(N.dot(N))
-	N=old_div(N,n)
+	N=N/n
 	xy_t=xy-p1
 	p=np.dot(xy_t,N)
 	P=np.empty_like(xy)
@@ -104,10 +100,10 @@ def find_line(p1,p2,pts): #linear regression, brute force or whatever...
 		f=found
 		xy=np.row_stack((p1,p2))
 		if abs(f[0])>abs(f[1]):
-			x=old_div((f[2]-xy[:,1]*f[1]),f[0])
+			x=(f[2]-xy[:,1]*f[1])/f[0]
 			xy2=np.column_stack((x,xy[:,1]))
 		else:
-			y=old_div((f[2]-xy[:,0]*f[0]),f[1])
+			y=(f[2]-xy[:,0]*f[0])/f[1]
 			xy2=np.column_stack((xy[:,0],y))
 		plot_points2(pts,xy2,xy)
 	rot=found[3]-angle
@@ -176,7 +172,7 @@ def check_distribution(p1,p2,xy):
 	f=(M.sum()/float(M.size))
 	#print("Fraction of points 'close' to line %.3f" %f)
 	h,bins=np.histogram(p,n_bins)
-	h=old_div(h.astype(np.float64),p.size)
+	h=h.astype(np.float64)/p.size
 	if (h<0.05).sum()>3:
 		print("Uneven distribution!")
 		return False,None

--- a/qc/xy_accuracy_buildings.py
+++ b/qc/xy_accuracy_buildings.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 ## work in progress...
 ###########################
 
+from builtins import str
+from builtins import range
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report

--- a/qc/xy_accuracy_buildings.py
+++ b/qc/xy_accuracy_buildings.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/xy_precision_buildings.py
+++ b/qc/xy_precision_buildings.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 ## work in progress...
 ###########################
 
+from builtins import str
+from builtins import range
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report
@@ -120,7 +122,7 @@ def search(xy,v1=0,v2=180,steps=30):
 	B=np.sin(V)
 	best=1e6
 	found=None
-	for i in xrange(A.shape[0]):
+	for i in range(A.shape[0]):
 		v=degrees(V[i])
 		c=A[i]*xy[:,0]+B[i]*xy[:,1]  #really a residual...
 		badness=np.var(c)   
@@ -339,7 +341,7 @@ def main(args):
 					#now find those corners!
 					lines_ok=dict()
 					found_lines=dict()
-					for vertex in xrange(a_poly.shape[0]-1): #check line emanating from vertex...
+					for vertex in range(a_poly.shape[0]-1): #check line emanating from vertex...
 						p1=a_poly[vertex]
 						p2=a_poly[vertex+1]
 						ok,pts=check_distribution(p1,p2,xy)

--- a/qc/xy_precision_buildings.py
+++ b/qc/xy_precision_buildings.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -20,6 +21,9 @@ from __future__ import print_function
 ## work in progress...
 ###########################
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report
@@ -79,7 +83,7 @@ def norm2(x):
 def residuals(p1,p2,xy):
 	N=(p2-p1)
 	n=np.sqrt(N.dot(N))
-	N=N/n
+	N=old_div(N,n)
 	xy_t=xy-p1
 	p=np.dot(xy_t,N)
 	P=np.empty_like(xy)
@@ -104,10 +108,10 @@ def find_line(p1,p2,pts): #linear regression, brute force or whatever...
 		f=found
 		xy=np.row_stack((p1,p2))
 		if abs(f[0])>abs(f[1]):
-			x=(f[2]-xy[:,1]*f[1])/f[0]
+			x=old_div((f[2]-xy[:,1]*f[1]),f[0])
 			xy2=np.column_stack((x,xy[:,1]))
 		else:
-			y=(f[2]-xy[:,0]*f[0])/f[1]
+			y=old_div((f[2]-xy[:,0]*f[0]),f[1])
 			xy2=np.column_stack((xy[:,0],y))
 		plot_points2(pts,xy2,xy)
 	rot=found[3]-angle
@@ -120,7 +124,7 @@ def search(xy,v1=0,v2=180,steps=30):
 	B=np.sin(V)
 	best=1e6
 	found=None
-	for i in xrange(A.shape[0]):
+	for i in range(A.shape[0]):
 		v=degrees(V[i])
 		c=A[i]*xy[:,0]+B[i]*xy[:,1]  #really a residual...
 		badness=np.var(c)   
@@ -189,7 +193,7 @@ def check_distribution(p1,p2,xy):
 	f=(M.sum()/float(M.size))
 	#print("Fraction of points 'close' to line %.3f" %f)
 	h,bins=np.histogram(p,n_bins)
-	h=h.astype(np.float64)/p.size
+	h=old_div(h.astype(np.float64),p.size)
 	if (h<0.05).sum()>3:
 		print("Uneven distribution!")
 		return False,None
@@ -339,7 +343,7 @@ def main(args):
 					#now find those corners!
 					lines_ok=dict()
 					found_lines=dict()
-					for vertex in xrange(a_poly.shape[0]-1): #check line emanating from vertex...
+					for vertex in range(a_poly.shape[0]-1): #check line emanating from vertex...
 						p1=a_poly[vertex]
 						p2=a_poly[vertex+1]
 						ok,pts=check_distribution(p1,p2,xy)

--- a/qc/xy_precision_buildings.py
+++ b/qc/xy_precision_buildings.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -21,9 +20,6 @@ from __future__ import division
 ## work in progress...
 ###########################
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 from qc.thatsDEM import pointcloud, vector_io, array_geometry
 from qc.db import report
@@ -83,7 +79,7 @@ def norm2(x):
 def residuals(p1,p2,xy):
 	N=(p2-p1)
 	n=np.sqrt(N.dot(N))
-	N=old_div(N,n)
+	N=N/n
 	xy_t=xy-p1
 	p=np.dot(xy_t,N)
 	P=np.empty_like(xy)
@@ -108,10 +104,10 @@ def find_line(p1,p2,pts): #linear regression, brute force or whatever...
 		f=found
 		xy=np.row_stack((p1,p2))
 		if abs(f[0])>abs(f[1]):
-			x=old_div((f[2]-xy[:,1]*f[1]),f[0])
+			x=(f[2]-xy[:,1]*f[1])/f[0]
 			xy2=np.column_stack((x,xy[:,1]))
 		else:
-			y=old_div((f[2]-xy[:,0]*f[0]),f[1])
+			y=(f[2]-xy[:,0]*f[0])/f[1]
 			xy2=np.column_stack((xy[:,0],y))
 		plot_points2(pts,xy2,xy)
 	rot=found[3]-angle
@@ -124,7 +120,7 @@ def search(xy,v1=0,v2=180,steps=30):
 	B=np.sin(V)
 	best=1e6
 	found=None
-	for i in range(A.shape[0]):
+	for i in xrange(A.shape[0]):
 		v=degrees(V[i])
 		c=A[i]*xy[:,0]+B[i]*xy[:,1]  #really a residual...
 		badness=np.var(c)   
@@ -193,7 +189,7 @@ def check_distribution(p1,p2,xy):
 	f=(M.sum()/float(M.size))
 	#print("Fraction of points 'close' to line %.3f" %f)
 	h,bins=np.histogram(p,n_bins)
-	h=old_div(h.astype(np.float64),p.size)
+	h=h.astype(np.float64)/p.size
 	if (h<0.05).sum()>3:
 		print("Uneven distribution!")
 		return False,None
@@ -343,7 +339,7 @@ def main(args):
 					#now find those corners!
 					lines_ok=dict()
 					found_lines=dict()
-					for vertex in range(a_poly.shape[0]-1): #check line emanating from vertex...
+					for vertex in xrange(a_poly.shape[0]-1): #check line emanating from vertex...
 						p1=a_poly[vertex]
 						p2=a_poly[vertex+1]
 						ok,pts=check_distribution(p1,p2,xy)

--- a/qc/xy_precision_buildings.py
+++ b/qc/xy_precision_buildings.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/z_accuracy.py
+++ b/qc/z_accuracy.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
+from builtins import str
+from builtins import range
 import sys,os,time
 import numpy as np
 from osgeo import ogr

--- a/qc/z_accuracy.py
+++ b/qc/z_accuracy.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
-from builtins import str
-from builtins import range
 import sys,os,time
 import numpy as np
 from osgeo import ogr

--- a/qc/z_accuracy.py
+++ b/qc/z_accuracy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/qc/z_accuracy_gcp.py
+++ b/qc/z_accuracy_gcp.py
@@ -18,6 +18,8 @@ from __future__ import absolute_import
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
+from builtins import str
+from builtins import range
 import sys,os,time
 import math
 import numpy as np

--- a/qc/z_accuracy_gcp.py
+++ b/qc/z_accuracy_gcp.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -20,10 +22,10 @@ import sys,os,time
 import math
 import numpy as np
 from osgeo import ogr
-from thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
-from db import report
-import dhmqc_constants as constants
-from utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
+from .thatsDEM import pointcloud,vector_io,array_geometry,array_factory,grid
+from .db import report
+from . import dhmqc_constants as constants
+from .utils.osutils import ArgumentParser  #If you want this script to be included in the test-suite use this subclass. Otherwise argparse.ArgumentParser will be the best choice :-)
 #path to geoid
 GEOID_GRID=os.path.join(os.path.dirname(__file__),"..","data","dkgeoid13b_utm32.tif")
 #The class(es) we want to look at...
@@ -58,7 +60,7 @@ def usage():
 def main(args):
 	try:
 		pargs=parser.parse_args(args[1:])
-	except Exception,e:
+	except Exception as e:
 		print(str(e))
 		return 1
 	kmname=constants.get_tilename(pargs.las_file)
@@ -71,7 +73,7 @@ def main(args):
 	reporter=report.ReportZcheckAbsGCP(use_local)
 	try:
 		extent=np.asarray(constants.tilename_to_extent(kmname))
-	except Exception,e:
+	except Exception as e:
 		print("Could not get extent from tilename.")
 		extent=None
 	xy_ref=[]
@@ -120,7 +122,7 @@ def main(args):
 		xy2=xy+(BUF,BUF)
 		pc_=pc.cut_to_box(xy1[0,0],xy1[0,1],xy2[0,0],xy2[0,1])
 		if pargs.debug:
-			print xy, xy.shape
+			print(xy, xy.shape)
 			print("Points in buffer: %d" %pc_.get_size())
 		wkt="POINT({0} {1} {2})".format(str(xy[0,0]),str(xy[0,1]),str(z_ref[i]))
 

--- a/qc/z_accuracy_gcp.py
+++ b/qc/z_accuracy_gcp.py
@@ -18,8 +18,6 @@ from __future__ import absolute_import
 #############################
 ## zcheck_abs script. Checks ogr point datasources against strips from pointcloud....
 #############################
-from builtins import str
-from builtins import range
 import sys,os,time
 import math
 import numpy as np

--- a/qc/z_precision_buildings.py
+++ b/qc/z_precision_buildings.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -18,10 +19,10 @@
 #########################
 import sys,os
 import numpy as np
-import zcheck_base
-import dhmqc_constants as const
-from db import report
-from utils.osutils import ArgumentParser
+from . import zcheck_base
+from . import dhmqc_constants as const
+from .db import report
+from .utils.osutils import ArgumentParser
 DEBUG="-debug" in sys.argv
 
 cut_to=[const.building,const.surface] 

--- a/qc/zcheck_base.py
+++ b/qc/zcheck_base.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 ## zcheck base script called by zcheck_build and 
 ## zcheck_road
 #############################
+from builtins import str
+from builtins import range
 import sys,os,time
 import numpy as np
 from qc.thatsDEM import pointcloud,vector_io,array_geometry
@@ -106,7 +108,7 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 					cut_geom=array_geometry.cut_geom_to_bbox(ogr_geom,overlap_box)
 					n_geoms=cut_geom.GetGeometryCount()
 					if n_geoms>0:
-						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in xrange(n_geoms)]
+						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in range(n_geoms)]
 						print("Cut line into %d pieces..." %n_geoms)
 				
 				for geom_piece in pieces:

--- a/qc/zcheck_base.py
+++ b/qc/zcheck_base.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -17,6 +18,9 @@ from __future__ import print_function
 ## zcheck base script called by zcheck_build and 
 ## zcheck_road
 #############################
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys,os,time
 import numpy as np
 from qc.thatsDEM import pointcloud,vector_io,array_geometry
@@ -106,7 +110,7 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 					cut_geom=array_geometry.cut_geom_to_bbox(ogr_geom,overlap_box)
 					n_geoms=cut_geom.GetGeometryCount()
 					if n_geoms>0:
-						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in xrange(n_geoms)]
+						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in range(n_geoms)]
 						print("Cut line into %d pieces..." %n_geoms)
 				
 				for geom_piece in pieces:
@@ -160,7 +164,7 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 						print("Reporting took %.4s ms - concurrency?" %((t2-t1)*1e3))
 	tend=time.clock()
 	tall=tend-tstart
-	frac_read=tread/tall
+	frac_read=old_div(tread,tall)
 	print("Finished checking tile, time spent: %.3f s, fraction spent on reading las data: %.3f" %(tall,frac_read))
 	return len(done)
 	

--- a/qc/zcheck_base.py
+++ b/qc/zcheck_base.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
@@ -18,9 +17,6 @@ from __future__ import division
 ## zcheck base script called by zcheck_build and 
 ## zcheck_road
 #############################
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys,os,time
 import numpy as np
 from qc.thatsDEM import pointcloud,vector_io,array_geometry
@@ -110,7 +106,7 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 					cut_geom=array_geometry.cut_geom_to_bbox(ogr_geom,overlap_box)
 					n_geoms=cut_geom.GetGeometryCount()
 					if n_geoms>0:
-						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in range(n_geoms)]
+						pieces=[cut_geom.GetGeometryRef(ng).Clone() for ng in xrange(n_geoms)]
 						print("Cut line into %d pieces..." %n_geoms)
 				
 				for geom_piece in pieces:
@@ -164,7 +160,7 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 						print("Reporting took %.4s ms - concurrency?" %((t2-t1)*1e3))
 	tend=time.clock()
 	tall=tend-tstart
-	frac_read=old_div(tread,tall)
+	frac_read=tread/tall
 	print("Finished checking tile, time spent: %.3f s, fraction spent on reading las data: %.3f" %(tall,frac_read))
 	return len(done)
 	

--- a/qc/zcheck_base.py
+++ b/qc/zcheck_base.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015, Danish Geodata Agency <gst@gst.dk>
 # 
 # Permission to use, copy, modify, and/or distribute this software for any

--- a/qc_wrap.py
+++ b/qc_wrap.py
@@ -21,6 +21,8 @@ Parallelization wrapper for tests in DHMQC
 
 from __future__ import print_function
 
+from builtins import str
+from builtins import range
 import sys
 import os
 import time

--- a/qc_wrap.py
+++ b/qc_wrap.py
@@ -20,7 +20,11 @@ Parallelization wrapper for tests in DHMQC
 '''
 
 from __future__ import print_function
+from __future__ import division
 
+from builtins import str
+from builtins import range
+from past.utils import old_div
 import sys
 import os
 import time
@@ -394,7 +398,7 @@ def main(args):
             dt_last_status = now - t_last_status
             if dt_last_report > 15:
                 if n_done > 0:
-                    delta = timedelta(seconds=n_left * (delta_t / n_done))
+                    delta = timedelta(seconds=n_left * (old_div(delta_t, n_done)))
                     t_left = str(delta - timedelta(microseconds=delta.microseconds))
                 else:
                     t_left = "unknown"

--- a/qc_wrap.py
+++ b/qc_wrap.py
@@ -20,11 +20,7 @@ Parallelization wrapper for tests in DHMQC
 '''
 
 from __future__ import print_function
-from __future__ import division
 
-from builtins import str
-from builtins import range
-from past.utils import old_div
 import sys
 import os
 import time
@@ -398,7 +394,7 @@ def main(args):
             dt_last_status = now - t_last_status
             if dt_last_report > 15:
                 if n_done > 0:
-                    delta = timedelta(seconds=n_left * (old_div(delta_t, n_done)))
+                    delta = timedelta(seconds=n_left * (delta_t / n_done))
                     t_left = str(delta - timedelta(microseconds=delta.microseconds))
                 else:
                     t_left = "unknown"

--- a/src/build/build.py
+++ b/src/build/build.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016-2018, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -27,7 +28,7 @@ from core import *
 
 HERE = os.getcwd()
 ROOT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
-print(HERE, ROOT_DIR)
+print((HERE, ROOT_DIR))
 
 # output binaries and source input defined here
 BIN_DIR = os.path.join(ROOT_DIR, "..", "qc", "thatsDEM", "lib")

--- a/src/build/build.py
+++ b/src/build/build.py
@@ -14,6 +14,8 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+from builtins import str
+from builtins import object
 import sys
 import os
 import platform

--- a/src/build/build.py
+++ b/src/build/build.py
@@ -14,8 +14,6 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-from builtins import str
-from builtins import object
 import sys
 import os
 import platform

--- a/src/build/cc.py
+++ b/src/build/cc.py
@@ -13,7 +13,6 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import object
 import sys
 IS_WINDOWS=sys.platform.startswith("win")
 IS_MAC="darwin" in sys.platform

--- a/src/build/cc.py
+++ b/src/build/cc.py
@@ -13,6 +13,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import object
 import sys
 IS_WINDOWS=sys.platform.startswith("win")
 IS_MAC="darwin" in sys.platform

--- a/src/build/core.py
+++ b/src/build/core.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import map
 import sys,os,subprocess,glob
 import cc
 
@@ -70,8 +71,8 @@ def build(compiler,outname,source,include=[],define=[],is_debug=False,is_library
         raise ValueError("Compiler must be a subclass of cc.ccompiler")
 
     #normalise paths - if not given as absolute paths...
-    includes=list(map(lambda x:compiler.INCLUDE_SWITCH+os.path.realpath(x),include))
-    defines=list(map(lambda x:compiler.DEFINE_SWITCH+x,define))
+    includes=list([compiler.INCLUDE_SWITCH+os.path.realpath(x) for x in include])
+    defines=list([compiler.DEFINE_SWITCH+x for x in define])
     source=list(map(os.path.realpath,source))
 
     #do not normalise link_libraries as it might contains a lot of 'non-path stuff' - use absolute paths her if you must - link_libraries=map(os.path.realpath,link_libraries)
@@ -107,7 +108,7 @@ def build(compiler,outname,source,include=[],define=[],is_debug=False,is_library
     else:
         obj_files=[os.path.splitext(os.path.basename(fname))[0]+compiler.OBJ_EXTENSION for fname in source]
     if compiler.IS_MSVC:
-        link_libraries=map(lambda x:x.replace(".dll",".lib"),link_libraries)
+        link_libraries=[x.replace(".dll",".lib") for x in link_libraries]
         link=[compiler.LINKER]+link_options+outname+[implib,def_file]+link_libraries+obj_files
     else:
         link=[compiler.LINKER]+link_options+outname+[implib]+obj_files+link_libraries+compiler.LINK_LIBRARIES+[def_file] #TODO - do something for MSVC also...

--- a/src/build/core.py
+++ b/src/build/core.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import map
 import sys,os,subprocess,glob
 import cc
 
@@ -71,8 +70,8 @@ def build(compiler,outname,source,include=[],define=[],is_debug=False,is_library
         raise ValueError("Compiler must be a subclass of cc.ccompiler")
 
     #normalise paths - if not given as absolute paths...
-    includes=list([compiler.INCLUDE_SWITCH+os.path.realpath(x) for x in include])
-    defines=list([compiler.DEFINE_SWITCH+x for x in define])
+    includes=list(map(lambda x:compiler.INCLUDE_SWITCH+os.path.realpath(x),include))
+    defines=list(map(lambda x:compiler.DEFINE_SWITCH+x,define))
     source=list(map(os.path.realpath,source))
 
     #do not normalise link_libraries as it might contains a lot of 'non-path stuff' - use absolute paths her if you must - link_libraries=map(os.path.realpath,link_libraries)
@@ -108,7 +107,7 @@ def build(compiler,outname,source,include=[],define=[],is_debug=False,is_library
     else:
         obj_files=[os.path.splitext(os.path.basename(fname))[0]+compiler.OBJ_EXTENSION for fname in source]
     if compiler.IS_MSVC:
-        link_libraries=[x.replace(".dll",".lib") for x in link_libraries]
+        link_libraries=map(lambda x:x.replace(".dll",".lib"),link_libraries)
         link=[compiler.LINKER]+link_options+outname+[implib,def_file]+link_libraries+obj_files
     else:
         link=[compiler.LINKER]+link_options+outname+[implib]+obj_files+link_libraries+compiler.LINK_LIBRARIES+[def_file] #TODO - do something for MSVC also...

--- a/src/build/core.py
+++ b/src/build/core.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+from builtins import object
 import os
 import time
 
@@ -50,7 +51,7 @@ def teardown_module():
     report.close_datasource()
     os.remove(OUTPUT_DS)
 
-class TestThatsDEM:
+class TestThatsDEM(object):
     '''
     Test modules in the thatsDEM package.
 
@@ -67,7 +68,7 @@ class TestThatsDEM:
     def test_triangle(self):
         triangle.unit_test()
 
-class TestKernels:
+class TestKernels(object):
     '''
     Test QC kernels.
 

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,3 @@
-from builtins import object
 import os
 import time
 
@@ -51,7 +50,7 @@ def teardown_module():
     report.close_datasource()
     os.remove(OUTPUT_DS)
 
-class TestThatsDEM(object):
+class TestThatsDEM:
     '''
     Test modules in the thatsDEM package.
 
@@ -68,7 +67,7 @@ class TestThatsDEM(object):
     def test_triangle(self):
         triangle.unit_test()
 
-class TestKernels(object):
+class TestKernels:
     '''
     Test QC kernels.
 

--- a/tile_coverage.py
+++ b/tile_coverage.py
@@ -23,8 +23,6 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-from builtins import next
-from builtins import object
 import os
 import sys
 import re

--- a/tile_coverage.py
+++ b/tile_coverage.py
@@ -23,6 +23,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+from builtins import next
+from builtins import object
 import os
 import sys
 import re

--- a/tools/class_check.py
+++ b/tools/class_check.py
@@ -1,7 +1,4 @@
 from __future__ import print_function
-from __future__ import division
-from builtins import str
-from past.utils import old_div
 import os,sys
 import argparse
 import subprocess
@@ -67,7 +64,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d"%(amount_of_files))
-print("  Total execution time: %.1f min" %(old_div(total_time,60)))
-print("  Average:              %.1f files/min" %(old_div(amount_of_files,(old_div(total_time,60)))))
+print("  Total execution time: %.1f min" %(total_time/60))
+print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
 print("------------------------------------------")
 print(" ")

--- a/tools/class_check.py
+++ b/tools/class_check.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os,sys
 import argparse
 import subprocess
@@ -48,9 +49,9 @@ exestrings.append("""python %s -testname wobbly_water -schema %s -tiles %s -runi
 
 
 for exestring in exestrings:
-	print "-------------------"
-	print exestring
-	print "-------------------"
+	print("-------------------")
+	print(exestring)
+	print("-------------------")
 	subprocess.call(exestring,shell=True)
 
 
@@ -58,12 +59,12 @@ end_time = time.time()
 
 total_time=end_time-start_time
 
-print " "
-print " "
-print "------------------------------------------"
-print "Summary: "
-print "  Files processed:      %d"%(amount_of_files)
-print "  Total execution time: %.1f min" %(total_time/60)
-print "  Average:              %.1f files/min" %(amount_of_files/(total_time/60))
-print "------------------------------------------"
-print " "
+print(" ")
+print(" ")
+print("------------------------------------------")
+print("Summary: ")
+print("  Files processed:      %d"%(amount_of_files))
+print("  Total execution time: %.1f min" %(total_time/60))
+print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
+print("------------------------------------------")
+print(" ")

--- a/tools/class_check.py
+++ b/tools/class_check.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import str
 import os,sys
 import argparse
 import subprocess

--- a/tools/class_check.py
+++ b/tools/class_check.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import division
+from builtins import str
+from past.utils import old_div
 import os,sys
 import argparse
 import subprocess
@@ -64,7 +67,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d"%(amount_of_files))
-print("  Total execution time: %.1f min" %(total_time/60))
-print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
+print("  Total execution time: %.1f min" %(old_div(total_time,60)))
+print("  Average:              %.1f files/min" %(old_div(amount_of_files,(old_div(total_time,60)))))
 print("------------------------------------------")
 print(" ")

--- a/tools/class_grids.py
+++ b/tools/class_grids.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from __future__ import division
+from past.utils import old_div
 import os
 import sys
 import argparse
@@ -84,7 +86,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d" % (amount_of_files))
-print("  Total execution time: %.1f min" % (total_time / 60))
-print("  Average:              %.1f files/min" % (amount_of_files / (total_time / 60)))
+print("  Total execution time: %.1f min" % (old_div(total_time, 60)))
+print("  Average:              %.1f files/min" % (old_div(amount_of_files, (old_div(total_time, 60)))))
 print("------------------------------------------")
 print(" ")

--- a/tools/class_grids.py
+++ b/tools/class_grids.py
@@ -1,6 +1,4 @@
 from __future__ import print_function
-from __future__ import division
-from past.utils import old_div
 import os
 import sys
 import argparse
@@ -86,7 +84,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d" % (amount_of_files))
-print("  Total execution time: %.1f min" % (old_div(total_time, 60)))
-print("  Average:              %.1f files/min" % (old_div(amount_of_files, (old_div(total_time, 60)))))
+print("  Total execution time: %.1f min" % (total_time / 60))
+print("  Average:              %.1f files/min" % (amount_of_files / (total_time / 60)))
 print("------------------------------------------")
 print(" ")

--- a/tools/class_grids.py
+++ b/tools/class_grids.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import argparse
@@ -47,7 +48,7 @@ for folder in ["class_grids", "dems", "diff", "hillshade_dtm", "hillshade_dsm"]:
 if not pargs.only_dems:
     call = 'python %s -testname class_grid -targs "class_grids -cs 1" -tiles %s' % (qc_wrap, pargs.tile_index)
     rc = subprocess.call(call, shell=True)
-    print rc
+    print(rc)
     subprocess.call("gdalbuildvrt class_grid.vrt class_grids/*.tif", shell=True)
     subprocess.call("gdaladdo -ro --config COMPRESS_OVERVIEW LZW class_grid.vrt 2 4 8 16", shell=True)
     if pargs.index_2007 is not None and os.path.exists(pargs.index_2007):
@@ -78,12 +79,12 @@ end_time = time.time()
 
 total_time = end_time - start_time
 
-print " "
-print " "
-print "------------------------------------------"
-print "Summary: "
-print "  Files processed:      %d" % (amount_of_files)
-print "  Total execution time: %.1f min" % (total_time / 60)
-print "  Average:              %.1f files/min" % (amount_of_files / (total_time / 60))
-print "------------------------------------------"
-print " "
+print(" ")
+print(" ")
+print("------------------------------------------")
+print("Summary: ")
+print("  Files processed:      %d" % (amount_of_files))
+print("  Total execution time: %.1f min" % (total_time / 60))
+print("  Average:              %.1f files/min" % (amount_of_files / (total_time / 60)))
+print("------------------------------------------")
+print(" ")

--- a/tools/class_total.py
+++ b/tools/class_total.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os,sys
 import argparse
 import subprocess
@@ -49,9 +50,9 @@ exestrings.append(class_grids_exestr)
 
 
 for exestring in exestrings:
-	print "-------------------"
-	print exestring
-	print "-------------------"
+	print("-------------------")
+	print(exestring)
+	print("-------------------")
 	subprocess.call(exestring,shell=True)
 	
 
@@ -59,12 +60,12 @@ end_time = time.time()
 
 total_time=end_time-start_time
 
-print " "
-print " "
-print "------------------------------------------"
-print "Summary of combined class check and gridding: "
-print "  Files processed:      %d"%(amount_of_files)
-print "  Total execution time: %.1f min" %(total_time/60)
-print "  Average:              %.1f files/min" %(amount_of_files/(total_time/60))
-print "------------------------------------------"
-print " "
+print(" ")
+print(" ")
+print("------------------------------------------")
+print("Summary of combined class check and gridding: ")
+print("  Files processed:      %d"%(amount_of_files))
+print("  Total execution time: %.1f min" %(total_time/60))
+print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
+print("------------------------------------------")
+print(" ")

--- a/tools/class_total.py
+++ b/tools/class_total.py
@@ -1,7 +1,4 @@
 from __future__ import print_function
-from __future__ import division
-from builtins import str
-from past.utils import old_div
 import os,sys
 import argparse
 import subprocess
@@ -68,7 +65,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary of combined class check and gridding: ")
 print("  Files processed:      %d"%(amount_of_files))
-print("  Total execution time: %.1f min" %(old_div(total_time,60)))
-print("  Average:              %.1f files/min" %(old_div(amount_of_files,(old_div(total_time,60)))))
+print("  Total execution time: %.1f min" %(total_time/60))
+print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
 print("------------------------------------------")
 print(" ")

--- a/tools/class_total.py
+++ b/tools/class_total.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import str
 import os,sys
 import argparse
 import subprocess

--- a/tools/class_total.py
+++ b/tools/class_total.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from __future__ import division
+from builtins import str
+from past.utils import old_div
 import os,sys
 import argparse
 import subprocess
@@ -65,7 +68,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary of combined class check and gridding: ")
 print("  Files processed:      %d"%(amount_of_files))
-print("  Total execution time: %.1f min" %(total_time/60))
-print("  Average:              %.1f files/min" %(amount_of_files/(total_time/60)))
+print("  Total execution time: %.1f min" %(old_div(total_time,60)))
+print("  Average:              %.1f files/min" %(old_div(amount_of_files,(old_div(total_time,60)))))
 print("------------------------------------------")
 print(" ")

--- a/tools/copytiles.py
+++ b/tools/copytiles.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 ##############
 ## Copy tiles from an ogr-layer to a dest folder
 ################
+from builtins import range
 import os,sys,time
 import shutil
 from osgeo import ogr

--- a/tools/copytiles.py
+++ b/tools/copytiles.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 ##############
 ## Copy tiles from an ogr-layer to a dest folder
 ################
-from builtins import range
 import os,sys,time
 import shutil
 from osgeo import ogr

--- a/tools/copytiles.py
+++ b/tools/copytiles.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/tools/deletetiles.py
+++ b/tools/deletetiles.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 ##############
 ## Delete tiles from an ogr-layer
 ################
+from builtins import input
+from builtins import range
 import os,sys,time
 import shutil
 from osgeo import ogr
@@ -42,7 +44,7 @@ def main(args):
 	if len(tilelist)==0:
 		print("No tiles...")
 		return
-	s=raw_input("Are you sure you want to delete all these tiles (YES)? ")
+	s=input("Are you sure you want to delete all these tiles (YES)? ")
 	if s.strip()!="YES":
 		print("OK - quitting.")
 		return

--- a/tools/deletetiles.py
+++ b/tools/deletetiles.py
@@ -17,8 +17,6 @@ from __future__ import print_function
 ##############
 ## Delete tiles from an ogr-layer
 ################
-from builtins import input
-from builtins import range
 import os,sys,time
 import shutil
 from osgeo import ogr
@@ -44,7 +42,7 @@ def main(args):
 	if len(tilelist)==0:
 		print("No tiles...")
 		return
-	s=input("Are you sure you want to delete all these tiles (YES)? ")
+	s=raw_input("Are you sure you want to delete all these tiles (YES)? ")
 	if s.strip()!="YES":
 		print("OK - quitting.")
 		return

--- a/tools/deletetiles.py
+++ b/tools/deletetiles.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/tools/geo_check.py
+++ b/tools/geo_check.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -69,21 +70,21 @@ exestrings.append("""python %s/qc_wrap.py %s/args/roof_ridge_align_args.py -runi
 exestrings.append("""python %s/qc_wrap.py %s/args/gcp_args.py -runid %s -refcon "%s" -schema %s -tiles %s """               % (DEV_PATH, DEV_PATH, RUNID, rl.REFCON, pargs.schema, pargs.tile_index))
 
 for exestring in exestrings:
-	print "-------------------"
-	print exestring
-	print "-------------------"
+	print("-------------------")
+	print(exestring)
+	print("-------------------")
 	subprocess.call(exestring, shell = True)
 
 end_time = time.time()
 
 total_time = end_time - start_time
 
-print " "
-print " "
-print "------------------------------------------"
-print "Summary: "
-print "  Files processed:      %d" % (amount_of_files)
-print "  Total execution time: %.1f min" % (total_time/60)
-print "  Average:              %.1f files/min" % (amount_of_files / (total_time/60))
-print "------------------------------------------"
-print " "
+print(" ")
+print(" ")
+print("------------------------------------------")
+print("Summary: ")
+print("  Files processed:      %d" % (amount_of_files))
+print("  Total execution time: %.1f min" % (total_time/60))
+print("  Average:              %.1f files/min" % (amount_of_files / (total_time/60)))
+print("------------------------------------------")
+print(" ")

--- a/tools/geo_check.py
+++ b/tools/geo_check.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 #
 
 
+from builtins import str
 import os
 import sys
 import time

--- a/tools/geo_check.py
+++ b/tools/geo_check.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -17,8 +16,6 @@ from __future__ import division
 #
 
 
-from builtins import str
-from past.utils import old_div
 import os
 import sys
 import time
@@ -87,7 +84,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d" % (amount_of_files))
-print("  Total execution time: %.1f min" % (old_div(total_time,60)))
-print("  Average:              %.1f files/min" % (old_div(amount_of_files, (old_div(total_time,60)))))
+print("  Total execution time: %.1f min" % (total_time/60))
+print("  Average:              %.1f files/min" % (amount_of_files / (total_time/60)))
 print("------------------------------------------")
 print(" ")

--- a/tools/geo_check.py
+++ b/tools/geo_check.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import division
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #
@@ -16,6 +17,8 @@ from __future__ import print_function
 #
 
 
+from builtins import str
+from past.utils import old_div
 import os
 import sys
 import time
@@ -84,7 +87,7 @@ print(" ")
 print("------------------------------------------")
 print("Summary: ")
 print("  Files processed:      %d" % (amount_of_files))
-print("  Total execution time: %.1f min" % (total_time/60))
-print("  Average:              %.1f files/min" % (amount_of_files / (total_time/60)))
+print("  Total execution time: %.1f min" % (old_div(total_time,60)))
+print("  Average:              %.1f files/min" % (old_div(amount_of_files, (old_div(total_time,60)))))
 print("------------------------------------------")
 print(" ")

--- a/tools/l2l.py
+++ b/tools/l2l.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+from builtins import range
 import os,sys
 from osgeo import ogr
 import argparse
@@ -34,7 +35,7 @@ def main(args):
 	ds=ogr.Open(pargs.tile_layer)
 	layer=ds.GetLayer(0)
 	nf=layer.GetFeatureCount()
-	for i in xrange(nf):
+	for i in range(nf):
 		feat=layer.GetNextFeature()
 		path=feat.GetFieldAsString(pargs.path_attr)
 		paths.add(path)
@@ -44,7 +45,7 @@ def main(args):
 	ds=ogr.Open(pargs.strip_layer)
 	layer=ds.GetLayer(0)
 	nf=layer.GetFeatureCount()
-	for i in xrange(nf):
+	for i in range(nf):
 		feat=layer.GetNextFeature()
 		pid=feat.GetFieldAsInteger(pargs.strip_attr)
 		pids.add(pid)

--- a/tools/l2l.py
+++ b/tools/l2l.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-from builtins import range
 import os,sys
 from osgeo import ogr
 import argparse
@@ -35,7 +34,7 @@ def main(args):
 	ds=ogr.Open(pargs.tile_layer)
 	layer=ds.GetLayer(0)
 	nf=layer.GetFeatureCount()
-	for i in range(nf):
+	for i in xrange(nf):
 		feat=layer.GetNextFeature()
 		path=feat.GetFieldAsString(pargs.path_attr)
 		paths.add(path)
@@ -45,7 +44,7 @@ def main(args):
 	ds=ogr.Open(pargs.strip_layer)
 	layer=ds.GetLayer(0)
 	nf=layer.GetFeatureCount()
-	for i in range(nf):
+	for i in xrange(nf):
 		feat=layer.GetNextFeature()
 		pid=feat.GetFieldAsInteger(pargs.strip_attr)
 		pids.add(pid)

--- a/tools/l2l.py
+++ b/tools/l2l.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #

--- a/tools/vrt2shade.py
+++ b/tools/vrt2shade.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 ## Stupid wrapper to hillshade tiles.. reads a buffer around each tile - 1px should be sufficient to remove edges...
 ## Will reduce hillshade output size A LOT For 'scattered' tiles. Build a vrt of output... 
 ############################################
-from builtins import str
-from builtins import range
 import os,sys,time
 import shlex, subprocess
 from osgeo import ogr

--- a/tools/vrt2shade.py
+++ b/tools/vrt2shade.py
@@ -18,6 +18,8 @@ from __future__ import print_function
 ## Stupid wrapper to hillshade tiles.. reads a buffer around each tile - 1px should be sufficient to remove edges...
 ## Will reduce hillshade output size A LOT For 'scattered' tiles. Build a vrt of output... 
 ############################################
+from builtins import str
+from builtins import range
 import os,sys,time
 import shlex, subprocess
 from osgeo import ogr

--- a/tools/vrt2shade.py
+++ b/tools/vrt2shade.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2015-2016, Danish Geodata Agency <gst@gst.dk>
 # Copyright (c) 2016, Danish Agency for Data Supply and Efficiency <sdfe@sdfe.dk>
 #


### PR DESCRIPTION
This is a competing PR to #33, using the `futurize` tool rather than `modernize` to convert from Python 2 to 3.

Since `modernize` is pretty noisy due to applying a lot of redundant brackets to `print` statements, I wanted to explore alternative conversion tools. `futurize` seems to do better here without any apparent loss of correctness.

The specific commands used here are `futurize . -w -n --stage1` followed by `futurize . -w -n --both-stages --nofix=libfuturize.fixes.fix_division_safe` (so that stage 2 fixes are applied in a separate commit).

The "stage 2" fixes are partially comprised of forward compatibility wrappers exposed in the `past` module, available when the `future` package is installed. It may seem like overkill to ~~introduce `past.old_div` all over the place and~~ wrap lots of iterators in `list()`, but this is probably the least-effort way to avoid regressions.

Edit: the `libfuturize.fixes.fix_division_safe` fix has been excluded. While it ostensibly guarantees behavior preservation, the `past.utils.old_div` function checks "integer-ness" using `isinstance(x, numbers.Integral)`, which does not apply correctly to NumPy arrays. Therefore, I think it's better to live with the un-converted division for now. Also, we don't have to install `future`.