### PR TITLE
Replace time.clock() with time.process_time()

### DIFF
--- a/qc/density_check.py
+++ b/qc/density_check.py
@@ -166,7 +166,7 @@ def main(args):
     band.WriteArray(den_grid)
     las_file.close()
 
-    t1 = time.clock()
+    t1 = time.process_time()
     if pargs.lakesql is None and pargs.seasql is None:
         print('No layer selection specified!')
         print('Assuming that all water polys are in first layer of connection...')
@@ -198,7 +198,7 @@ def main(args):
                 pargs.seasql,
             )
 
-    t2 = time.clock()
+    t2 = time.process_time()
     print("Burning 'water' took: %.3f s" % (t2 - t1))
 
     # what to do with nodata??

--- a/qc/pointcloud_diff.py
+++ b/qc/pointcloud_diff.py
@@ -122,7 +122,7 @@ def main(args):
 		geoid=grid.fromGDAL(GEOID_GRID,upcast=True)
 		print("Using geoid from %s to warp to ellipsoidal heights." %GEOID_GRID)
 		pc_ref.toE(geoid)
-	t0=time.clock()
+	t0=time.process_time()
 	pc.sort_spatially(pargs.srad)
 	z_new=pc.idw_filter(pargs.srad,xy=pc_ref.xy,nd_val=ND_VAL)
 	M=(z_new!=ND_VAL)
@@ -135,9 +135,9 @@ def main(args):
 	pc_ref.sort_spatially(0.7*cs)
 	xy=pointcloud.mesh_as_points((nrows,ncols),geo_ref)
 	
-	t1=time.clock()
+	t1=time.process_time()
 	dz_grid=pc_ref.mean_filter(0.6*cs,xy=xy,nd_val=ND_VAL).reshape((nrows,ncols)) #or median here...
-	t2=time.clock()
+	t2=time.process_time()
 	print("Final filtering: %.3f s" %(t2-t1))
 	print("All in all: %.3f s" %(t2-t0))
 	g=grid.Grid(dz_grid,geo_ref,ND_VAL)

--- a/qc/set_lake_z.py
+++ b/qc/set_lake_z.py
@@ -111,10 +111,10 @@ def main(args):
     pc=None
     #select all lakes that intersect this tile and for which the burn h is not set,,,
     print(sql_commands["select_relevant"])
-    t1=time.clock()
+    t1=time.process_time()
     cur.execute(sql_commands["select_relevant"])
     lake_ids=cur.fetchall() #some of the same lakes might be included in another query in another process - handle this better..
-    t2=time.clock()
+    t2=time.process_time()
     print("Found %d lakes in %.3f s" %(len(lake_ids),t2-t1))
     tg=ogr.CreateGeometryFromWkt(tilewkt)
     for lake_id in lake_ids:

--- a/qc/thatsDEM/triangle.py
+++ b/qc/thatsDEM/triangle.py
@@ -323,7 +323,7 @@ class Triangulation(TriangulationBase):
         self.ntrig = num_faces.value
         self.vertices = self.ptr_faces.contents
         #print("Triangles: %d" %self.ntrig)
-        t1 = time.clock()
+        t1 = time.process_time()
         self.index = lib.build_index(
             points.ctypes.data_as(LP_CDOUBLE),
             self.vertices,
@@ -332,7 +332,7 @@ class Triangulation(TriangulationBase):
             self.ntrig)
         if self.index is None:
             raise Exception("Failed to build index...")
-        t2 = time.clock()
+        t2 = time.process_time()
 
 
 def unit_test(n1=1000, n2=1000):
@@ -348,28 +348,28 @@ def unit_test(n1=1000, n2=1000):
     dy = (ymax - ymin)
     cx, cy = points.mean(axis=0)
     xy = np.random.rand(n2, 2) * [dx, dy] * 0.3 + [cx, cy]
-    t1 = time.clock()
+    t1 = time.process_time()
     tri = Triangulation(points, -1)
-    t2 = time.clock()
+    t2 = time.process_time()
     t3 = t2 - t1
     print("Building triangulation and index of %d points: %.4f s" % (n1, t3))
     print(tri.inspect_index())
-    t1 = time.clock()
+    t1 = time.process_time()
     tri.optimize_index()
-    t2 = time.clock()
+    t2 = time.process_time()
     t3 = t2 - t1
     print("\n%s\nOptimizing index: %.4fs" % ("*" * 50, t3))
     print(tri.inspect_index())
-    t1 = time.clock()
+    t1 = time.process_time()
     T = tri.find_triangles(xy)
-    t2 = time.clock()
+    t2 = time.process_time()
     t3 = t2 - t1
     print("Finding %d simplices: %.4f s, pr. 1e6: %.4f s" % (n2, t3, t3 / n2 * 1e6))
     assert T.min() >= 0
     assert T.max() < tri.ntrig
-    t1 = time.clock()
+    t1 = time.process_time()
     zi = tri.interpolate(z, points)
-    t2 = time.clock()
+    t2 = time.process_time()
     t3 = t2 - t1
     print("Interpolation test of vertices:  %.4f s, pr. 1e6: %.4f s" % (t3, t3 / n1 * 1e6))
     D = np.fabs(z - zi)

--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -180,7 +180,7 @@ def get_geometries(cstr, layername=None, layersql=None, extent=None, explode=Tru
     """
     # If executing fancy sql like selecting buffers etc, be sure to add a
     # where ST_Intersects(geom,TILE_POLY) - otherwise its gonna be slow....
-    t1 = time.clock()
+    t1 = time.process_time()
     ds, layer = open(cstr, layername, layersql, extent)
     if extent is not None:
         layer.SetSpatialFilterRect(float(extent[0]), float(extent[1]), float(extent[2]), float(extent[3]))
@@ -204,7 +204,7 @@ def get_geometries(cstr, layername=None, layersql=None, extent=None, explode=Tru
         ds.ReleaseResultSet(layer)
     layer = None
     ds = None
-    t2 = time.clock()
+    t2 = time.process_time()
     print("Fetching geoms took %.3f s" % (t2 - t1))
     return geoms
 

--- a/qc/zcheck_base.py
+++ b/qc/zcheck_base.py
@@ -42,10 +42,10 @@ def check_feature(pc1,pc2_in_poly,a_geom,DEBUG=False):
 def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_class,reporter,buffer_dist=None,layername=None,layersql=None):
 	is_roads=buffer_dist is not None #'hacky' signal that its roads we're checking
 	print("Starting zcheck_base run at %s" %time.asctime())
-	tstart=time.clock()
+	tstart=time.process_time()
 	kmname=constants.get_tilename(lasname)
 	pc=pointcloud.fromAny(lasname)
-	t2=time.clock()
+	t2=time.process_time()
 	tread=t2-tstart
 	print("Reading data took %.3f ms" %(tread*1e3))
 	try:
@@ -156,11 +156,11 @@ def zcheck_base(lasname,vectorname,angle_tolerance,xy_tolerance,z_tolerance,cut_
 						for i in range(4):
 							args.extend([args12[i],args21[i]])
 						args.append(c_prec)
-						t1=time.clock()
+						t1=time.process_time()
 						reporter.report(*args,ogr_geom=geom_piece)
-						t2=time.clock()
+						t2=time.process_time()
 						print("Reporting took %.4s ms - concurrency?" %((t2-t1)*1e3))
-	tend=time.clock()
+	tend=time.process_time()
 	tall=tend-tstart
 	frac_read=tread/tall
 	print("Finished checking tile, time spent: %.3f s, fraction spent on reading las data: %.3f" %(tall,frac_read))


### PR DESCRIPTION
Replaces calls to `time.clock()`, which has been removed in Python 3.8, with `time.process_time()` (introduced in Python 3.3).

Closes #40 