### PR TITLE
Fix extent handling in vector_io.get_features()

### DIFF
--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -218,7 +218,7 @@ def get_features(cstr, layername=None, layersql=None, extent=None):
 
     ds, layer = open(cstr, layername, layersql, extent)
     if extent is not None:
-        layer.SetSpatialFilterRect(*extent.astype(np.float))
+        layer.SetSpatialFilterRect(*[float(coord) for coord in extent])
     feats = [f for f in layer]
     if layersql is not None:
         ds.ReleaseResultSet(layer)

--- a/qc/thatsDEM/vector_io.py
+++ b/qc/thatsDEM/vector_io.py
@@ -218,7 +218,7 @@ def get_features(cstr, layername=None, layersql=None, extent=None):
 
     ds, layer = open(cstr, layername, layersql, extent)
     if extent is not None:
-        layer.SetSpatialFilterRect(*extent)
+        layer.SetSpatialFilterRect(*extent.astype(np.float))
     feats = [f for f in layer]
     if layersql is not None:
         ds.ReleaseResultSet(layer)


### PR DESCRIPTION
Fixes #45 

The problem was that the `extent` passed around is a NumPy array with data type `int32`, which could not be unpacked to match the method signature `SetSpatialFilterRect(double,double,double,double)`.