### PR TITLE
Unpin numpy version in CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  # gdal pinned to 3.0.1 due to otherwise incompatible libpoppler version. numpy pinned to 1.16 due to laspy issue #112. Feel free to remove version pinning here once they are fixed.
-  - conda create -q -n dhmqc_env -c conda-forge gdal=3.0.1 owslib psycopg2 numpy=1.16 scipy pandas laspy laszip lastools nose coverage coveralls
+  # gdal pinned to 3.0.1 due to otherwise incompatible libpoppler version. Feel free to remove version pinning here once it is fixed.
+  - conda create -q -n dhmqc_env -c conda-forge gdal=3.0.1 owslib psycopg2 numpy scipy pandas laspy laszip lastools nose coverage coveralls
   - conda activate dhmqc_env
   - python src/build/build.py -v -x64 -force -cc gcc -cxx g++
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,8 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  # python pinned to 3.7 as a workaround to avoid dealing with stricter Windows DLL resolution in Python 3.8. numpy pinned to 1.16 due to laspy issue #112. Feel free to remove version pinning once these are fixed.
-  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy=1.16 scipy pandas laspy laszip lastools nose python=3.7
+  # python pinned to 3.7 as a workaround to avoid dealing with stricter Windows DLL resolution in Python 3.8. Feel free to remove version pinning once this is fixed.
+  - conda create -n %CONDA_ENV_NAME% -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose python=3.7
   # AppVeyor has its own activate.bat in lieu of "conda activate"
   - activate %CONDA_ENV_NAME%
   - echo %PATH%


### PR DESCRIPTION
Now that [laspy#112](https://github.com/laspy/laspy/issues/112) is (mostly) fixed (with laspy v1.7.0), we can unpin the NumPy version.