### PR TITLE
Unpin GDAL version in Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  # gdal pinned to 3.0.1 due to otherwise incompatible libpoppler version. Feel free to remove version pinning here once it is fixed.
-  - conda create -q -n dhmqc_env -c conda-forge gdal=3.0.1 owslib psycopg2 numpy scipy pandas laspy laszip lastools nose coverage coveralls
+  - conda create -q -n dhmqc_env -c conda-forge gdal owslib psycopg2 numpy scipy pandas laspy laszip lastools nose coverage coveralls
   - conda activate dhmqc_env
   - python src/build/build.py -v -x64 -force -cc gcc -cxx g++
 


### PR DESCRIPTION
New versions of GDAL released, should fix the linking issues.