### PR TITLE
Remove unused pandas dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - psycopg2
   - numpy
   - scipy
-  - pandas
   - laspy>=2.0
   # There are currently no conda-forge packages for the Python bindings of
   # either laz-rs or LASzip, so get them with pip


### PR DESCRIPTION
pandas is no longer used after `pc_repair_man` has been removed.