### PR TITLE
Use laszip as LAZ backend

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   # either laz-rs or LASzip, so get them with pip
   - pip
   - pip:
-    - lazrs
+    # Consider replacing with lazrs if it is deemed sufficiently reliable
+    - laszip
   # For testing only
   - nose


### PR DESCRIPTION
Using `lazrs` as backend seems to give some cases of `pylaz.LazrsError: IoError: failed to fill whole buffer` when used on real-life data. Use classic `laszip` LAZ backend until that is sorted out.